### PR TITLE
feat(people-lite): add fee-backed registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5080,6 +5080,7 @@ dependencies = [
  "indiv-pallet-people-lite",
  "indiv-support",
  "log",
+ "pallet-balances",
  "parity-scale-codec",
  "parking_lot",
  "scale-info",

--- a/pallets/game/src/mock_runtime.rs
+++ b/pallets/game/src/mock_runtime.rs
@@ -950,6 +950,8 @@ parameter_types! {
 	pub const NetworkSuffix: &'static [u8] = b"paseo";
 	pub const LiteCollectionOwner: u32 = 2;
 	pub const LiteRingExp: RingExponent = RingExponent::R2e9;
+	pub const LitePeoplePotId: PalletId = PalletId(*b"plitefee");
+	pub const LitePersonRegistrationFee: u64 = 10;
 }
 
 /// The contexts in which lite people may bind an account, see
@@ -964,6 +966,9 @@ impl frame_support::traits::Contains<Context> for LiteAccountContexts {
 
 impl indiv_pallet_people_lite::Config for Test {
 	type WeightInfo = ();
+	type Currency = Balances;
+	type PotId = LitePeoplePotId;
+	type RegistrationFee = LitePersonRegistrationFee;
 	type Suffix = NetworkSuffix;
 	type AttestationAllowanceManager = EnsureRoot<Self::AccountId>;
 	type MemberService = Members;

--- a/pallets/people-lite/src/benchmarking.rs
+++ b/pallets/people-lite/src/benchmarking.rs
@@ -398,9 +398,7 @@ mod benches {
 		let sk = CryptoOf::<T>::new_secret([12; 32]);
 		let pk = CryptoOf::<T>::member_from_secret(&sk);
 
-		let mut msg = MSG_PREFIX.to_vec();
-		msg.extend_from_slice(&att.encode());
-		msg.extend_from_slice(&pk.encode());
+		let msg = Pallet::<T>::registration_message(&att, &pk);
 
 		let (_, att_sig) = T::BenchmarkHelper::sign_message(&msg[..]);
 		let proof_of_ownership = CryptoOf::<T>::sign(&sk, &msg[..]).unwrap();
@@ -416,6 +414,28 @@ mod benches {
 		assert!(crate::LitePeopleCollectionCreated::<T>::get());
 		frame_system::Pallet::<T>::assert_last_event(
 			crate::Event::<T>::PersonAttested { candidate: att, verifier: attester }.into(),
+		);
+		Ok(())
+	}
+
+	#[benchmark]
+	fn register_with_fee() -> Result<(), BenchmarkError> {
+		let candidate: T::AccountId = whitelisted_caller();
+		let balance = T::RegistrationFee::get().saturating_add(T::Currency::minimum_balance());
+		assert_ok!(T::Currency::mint_into(&candidate, balance));
+		ensure_lite_collection::<T>()?;
+
+		let secret = CryptoOf::<T>::new_secret([13; 32]);
+		let ring_vrf_key = CryptoOf::<T>::member_from_secret(&secret);
+		let message = Pallet::<T>::registration_message(&candidate, &ring_vrf_key);
+		let proof_of_ownership = CryptoOf::<T>::sign(&secret, &message).unwrap();
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(candidate.clone()), ring_vrf_key, proof_of_ownership, None);
+
+		assert!(crate::LitePeople::<T>::contains_key(&candidate));
+		frame_system::Pallet::<T>::assert_last_event(
+			crate::Event::<T>::PersonRegisteredWithFee { candidate }.into(),
 		);
 		Ok(())
 	}

--- a/pallets/people-lite/src/lib.rs
+++ b/pallets/people-lite/src/lib.rs
@@ -24,11 +24,16 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::borrowed_box)]
 extern crate alloc;
-use alloc::{boxed::Box, vec};
+use alloc::{boxed::Box, vec, vec::Vec};
 use codec::Encode;
 use frame_support::{
 	dispatch::{DispatchResultWithPostInfo, PostDispatchInfo},
-	traits::IsSubType,
+	traits::{
+		fungible::{Inspect, Mutate},
+		tokens::Preservation,
+		IsSubType,
+	},
+	PalletId,
 };
 use indiv_support::{
 	traits::{
@@ -39,7 +44,7 @@ use indiv_support::{
 	tx_priority,
 };
 use sp_runtime::{
-	traits::{Dispatchable, IdentifyAccount, Verify},
+	traits::{AccountIdConversion, Dispatchable, IdentifyAccount, Verify},
 	Saturating,
 };
 use types::{
@@ -80,6 +85,10 @@ pub mod pallet {
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
 
+	/// Native balance used to pay the lite-person registration fee.
+	pub type BalanceOf<T> =
+		<<T as Config>::Currency as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
+
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn integrity_test() {
@@ -99,6 +108,19 @@ pub mod pallet {
 	{
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
+
+		/// Native currency used to collect the lite-person registration fee.
+		type Currency: Mutate<Self::AccountId>;
+
+		/// Account identifier used to derive the account that receives registration fees.
+		#[pallet::constant]
+		type PotId: Get<PalletId>;
+
+		/// Fee required to register as a lite person without device attestation.
+		///
+		/// The getter can use a dynamic parameter or future pricing adapter without changing this
+		/// pallet.
+		type RegistrationFee: Get<BalanceOf<Self>>;
 
 		/// Network suffix appended to this pallet's product name.
 		#[pallet::constant]
@@ -201,6 +223,8 @@ pub mod pallet {
 		AttestationAllowanceIncreased { account: T::AccountId, count: u32 },
 		/// A new lite person was registered through attestation.
 		PersonAttested { candidate: T::AccountId, verifier: T::AccountId },
+		/// A new lite person was registered by paying the registration fee.
+		PersonRegisteredWithFee { candidate: T::AccountId },
 		/// A lite person was registered as a consumer.
 		ConsumerRegistered { account: T::AccountId },
 		/// An alias-to-account mapping was set or updated.
@@ -213,6 +237,11 @@ pub mod pallet {
 
 	#[pallet::extra_constants]
 	impl<T: Config> Pallet<T> {
+		/// The account that receives non-refundable lite-person registration fees.
+		pub fn lite_people_pot_id() -> T::AccountId {
+			T::PotId::get().into_account_truncating()
+		}
+
 		/// The context used to authenticate lite people.
 		pub fn auth_context() -> Context {
 			indiv_support::context::build_product_context(
@@ -252,6 +281,8 @@ pub mod pallet {
 		InvalidAliasContext,
 		/// The lite people member collection has not been initialized yet.
 		LitePeopleCollectionNotCreated,
+		/// The consumer registration account does not match the candidate.
+		InvalidConsumerRegistrationAccount,
 	}
 
 	#[pallet::call]
@@ -356,9 +387,7 @@ pub mod pallet {
 				.ok_or(Error::<T>::NoAttestationAllowance)?;
 			Self::ensure_lite_collection_created()?;
 
-			let msg = candidate.using_encoded(|c_bytes| {
-				ring_vrf_key.using_encoded(|rv_bytes| [&MSG_PREFIX[..], c_bytes, rv_bytes].concat())
-			});
+			let msg = Self::registration_message(&candidate, &ring_vrf_key);
 			ensure!(
 				CryptoOf::<T>::verify_signature(&proof_of_ownership, &msg[..], &ring_vrf_key),
 				Error::<T>::InvalidProofOfOwnership,
@@ -396,6 +425,84 @@ pub mod pallet {
 			}
 
 			Ok(Pays::No.into())
+		}
+
+		/// Register as a lite person by paying the configured native registration fee.
+		///
+		/// The origin must be the candidate's signed account. The candidate proves ownership of the
+		/// `ring_vrf_key` by signing the same registration message used by [`Self::attest`].
+		///
+		/// On success, this call transfers the configured fee to the pallet pot, stores lite
+		/// registration data in `LitePeople` and adds the ring VRF key to the lite member
+		/// collection. The fee is not refunded.
+		///
+		/// The lite member collection must already have been created via the
+		/// `migration::CreateLitePeopleCollection` runtime upgrade or
+		/// [`Call::create_lite_people_collection`].
+		///
+		/// - `ring_vrf_key`: The ring VRF key to be associated with the lite person.
+		/// - `proof_of_ownership`: The ring VRF signature proving ownership of `ring_vrf_key`.
+		/// - `consumer_registration`: Optional parameters to register the candidate as a lite
+		///   consumer. The request must contain a signature over the usual consumer payload with
+		///   the signed candidate account in both the account and verifier positions.
+		#[pallet::call_index(3)]
+		#[pallet::weight(if consumer_registration.is_some() {
+			<T as Config>::WeightInfo::register_with_fee()
+				.saturating_add(<T as Config>::WeightInfo::register_lite_consumer())
+		} else {
+			<T as Config>::WeightInfo::register_with_fee()
+		})]
+		pub fn register_with_fee(
+			origin: OriginFor<T>,
+			ring_vrf_key: MemberOf<T>,
+			proof_of_ownership: SignatureOf<T>,
+			consumer_registration: Option<LiteConsumerRegistrationParamsOf<T>>,
+		) -> DispatchResult {
+			let candidate = ensure_signed(origin)?;
+			ensure!(!LitePeople::<T>::contains_key(&candidate), Error::<T>::AlreadyRegistered);
+			ensure!(
+				T::MemberService::member_status(LITE_PEOPLE_MEMBER_IDENTIFIER, &ring_vrf_key)
+					.is_none(),
+				Error::<T>::KeyAlreadyInUse,
+			);
+			if let Some(params) = &consumer_registration {
+				ensure!(
+					params.account == candidate,
+					Error::<T>::InvalidConsumerRegistrationAccount
+				);
+			}
+			Self::ensure_lite_collection_created()?;
+
+			let msg = Self::registration_message(&candidate, &ring_vrf_key);
+			ensure!(
+				CryptoOf::<T>::verify_signature(&proof_of_ownership, &msg[..], &ring_vrf_key),
+				Error::<T>::InvalidProofOfOwnership,
+			);
+			let registration_fee = T::RegistrationFee::get();
+			let transferred = T::Currency::transfer(
+				&candidate,
+				&Self::lite_people_pot_id(),
+				registration_fee,
+				Preservation::Preserve,
+			)?;
+			debug_assert_eq!(transferred, registration_fee);
+			let ring_vrf_key_for_member_service = ring_vrf_key.clone();
+			LitePeople::<T>::insert(
+				&candidate,
+				LitePersonInfo { ring_vrf_key, method: RecognitionMethod::Fee },
+			);
+			T::MemberService::add_members(
+				LITE_PEOPLE_MEMBER_IDENTIFIER,
+				vec![ring_vrf_key_for_member_service],
+			)?;
+			frame_system::Pallet::<T>::inc_sufficients(&candidate);
+			Self::deposit_event(Event::PersonRegisteredWithFee { candidate: candidate.clone() });
+
+			if let Some(params) = consumer_registration {
+				Self::register_lite_consumer(params, &candidate)?;
+			}
+
+			Ok(())
 		}
 
 		#[pallet::call_index(5)]
@@ -524,6 +631,18 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
+		/// Creates the message a candidate signs to prove ownership of a ring VRF key.
+		pub(crate) fn registration_message(
+			candidate: &T::AccountId,
+			ring_vrf_key: &MemberOf<T>,
+		) -> Vec<u8> {
+			candidate.using_encoded(|candidate_bytes| {
+				ring_vrf_key.using_encoded(|key_bytes| {
+					[&MSG_PREFIX[..], candidate_bytes, key_bytes].concat()
+				})
+			})
+		}
+
 		/// Validates that the lite people collection can be created.
 		///
 		/// Returns a valid transaction if the collection doesn't exist yet,

--- a/pallets/people-lite/src/mock.rs
+++ b/pallets/people-lite/src/mock.rs
@@ -28,6 +28,7 @@ use frame_support::{
 	dispatch::{DispatchErrorWithPostInfo, GetDispatchInfo},
 	parameter_types,
 	storage::with_transaction,
+	PalletId,
 };
 use frame_system::EnsureRoot;
 use indiv_support::traits::{
@@ -107,6 +108,7 @@ impl frame_system::Config for Test {
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
 impl pallet_balances::Config for Test {
 	type AccountStore = System;
+	type RuntimeHoldReason = RuntimeHoldReason;
 }
 
 impl alias_target::Config for Test {}
@@ -133,6 +135,9 @@ impl frame_support::traits::Contains<indiv_support::traits::Context> for LiteAcc
 
 impl crate::Config for Test {
 	type WeightInfo = ();
+	type Currency = Balances;
+	type PotId = LitePeoplePotId;
+	type RegistrationFee = LitePersonRegistrationFee;
 	type Suffix = NetworkSuffix;
 	type AttestationAllowanceManager = EnsureRoot<Self::AccountId>;
 	type MemberService = MockMemberService;
@@ -140,13 +145,15 @@ impl crate::Config for Test {
 	type LiteRingExponent = LiteRingExponentConst;
 	type LiteOnboardingSize = LiteOnboardingSizeConst;
 	type AttestationSignature = UintAuthorityId;
-	type LiteConsumerRegistrar = ();
+	type LiteConsumerRegistrar = MockConsumerRegistrar;
 	type AccountContexts = LiteAccountContexts;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = Helper;
 }
 
 parameter_types! {
+	pub storage LitePersonRegistrationFee: u64 = 10;
+	pub const LitePeoplePotId: PalletId = PalletId(*b"plitefee");
 	pub const NetworkSuffix: &'static [u8] = b"paseo";
 	pub const LiteCollectionOwnerConst: u32 = 42;
 	pub const LiteRingExponentConst: RingExponent = RingExponent::R2e9;
@@ -158,6 +165,26 @@ thread_local! {
 	static MOCK_COLLECTION_MEMBERS: RefCell<BTreeMap<Identifier, Vec<<Mock as verifiable::GenerateVerifiable>::Member>>> = const { RefCell::new(BTreeMap::new()) };
 	static MOCK_COLLECTION_REVISIONS: RefCell<BTreeMap<Identifier, RevisionIndex>> = const { RefCell::new(BTreeMap::new()) };
 	static MOCK_FAIL_NEXT_ADD_MEMBERS: RefCell<bool> = const { RefCell::new(false) };
+	static MOCK_REGISTERED_CONSUMERS: RefCell<Vec<u64>> = const { RefCell::new(Vec::new()) };
+	static MOCK_FAIL_NEXT_CONSUMER_REGISTRATION: RefCell<bool> = const { RefCell::new(false) };
+}
+
+pub struct MockConsumerRegistrar;
+impl indiv_support::traits::ConsumerRegistrar<u64> for MockConsumerRegistrar {
+	type Error = DispatchError;
+
+	fn register_lite_consumer(
+		account: u64,
+		_identifier_key: indiv_support::traits::CommunicationIdentifier,
+		_username: indiv_support::traits::Username,
+		_reserved_username: Option<indiv_support::traits::Username>,
+	) -> Result<(), Self::Error> {
+		if MOCK_FAIL_NEXT_CONSUMER_REGISTRATION.with(|flag| flag.replace(false)) {
+			return Err(DispatchError::Other("mock consumer registration failed"));
+		}
+		MOCK_REGISTERED_CONSUMERS.with(|consumers| consumers.borrow_mut().push(account));
+		Ok(())
+	}
 }
 
 pub fn mock_member_service_members(
@@ -191,12 +218,22 @@ pub fn mock_member_service_fail_next_add_members() {
 	});
 }
 
+pub fn mock_registered_consumers() -> Vec<u64> {
+	MOCK_REGISTERED_CONSUMERS.with(|consumers| consumers.borrow().clone())
+}
+
+pub fn mock_consumer_registrar_fail_next() {
+	MOCK_FAIL_NEXT_CONSUMER_REGISTRATION.with(|flag| *flag.borrow_mut() = true);
+}
+
 fn reset_mock_member_service_state() {
 	MOCK_COLLECTIONS.with(|collections| collections.borrow_mut().clear());
 	MOCK_COLLECTION_MEMBERS
 		.with(|members_by_collection| members_by_collection.borrow_mut().clear());
 	MOCK_COLLECTION_REVISIONS.with(|revisions| revisions.borrow_mut().clear());
 	MOCK_FAIL_NEXT_ADD_MEMBERS.with(|flag| *flag.borrow_mut() = false);
+	MOCK_REGISTERED_CONSUMERS.with(|consumers| consumers.borrow_mut().clear());
+	MOCK_FAIL_NEXT_CONSUMER_REGISTRATION.with(|flag| *flag.borrow_mut() = false);
 }
 
 pub struct MockMemberService;

--- a/pallets/people-lite/src/tests.rs
+++ b/pallets/people-lite/src/tests.rs
@@ -19,24 +19,25 @@ use crate::{
 		alias_target, exec_as_lite_alias_with_account_revised_tx,
 		exec_as_lite_alias_with_account_tx, exec_as_lite_alias_with_proof_tx,
 		exec_as_lite_alias_with_proof_tx_at_rev, exec_as_lite_person_tx, exec_signed_tx, exec_tx,
-		mock_member_service_delete_collection, mock_member_service_fail_next_add_members,
-		mock_member_service_members, mock_member_service_revision, new_test_ext, Extrinsic,
-		RuntimeCall, RuntimeEvent, RuntimeOrigin, Test, TransactionExecutionError,
-		OTHER_LITE_CONTEXT,
+		mock_consumer_registrar_fail_next, mock_member_service_delete_collection,
+		mock_member_service_fail_next_add_members, mock_member_service_members,
+		mock_member_service_revision, mock_registered_consumers, new_test_ext, Extrinsic,
+		LitePersonRegistrationFee, RuntimeCall, RuntimeEvent, RuntimeOrigin, Test,
+		TransactionExecutionError, OTHER_LITE_CONTEXT,
 	},
 	pallet::{AccountToAlias, AliasToAccount, AttestationAllowance, LitePeople},
 	EnsureLiteAliasInContext, LitePeopleCollectionCreated, MemberOf, Pallet as PeopleLitePallet,
-	ProofOf, LITE_PEOPLE_MEMBER_IDENTIFIER, MSG_PREFIX,
+	ProofOf, LITE_PEOPLE_MEMBER_IDENTIFIER,
 };
 use codec::Encode;
 use frame_support::{
 	assert_noop, assert_ok,
-	dispatch::Pays,
-	traits::{EnsureOriginWithArg, OnRuntimeUpgrade},
+	dispatch::{GetDispatchInfo, Pays},
+	traits::{fungible::InspectHold, Currency, EnsureOriginWithArg, OnRuntimeUpgrade},
 };
 use frame_system::Pallet;
 use indiv_support::traits::{AppendOnlyMembers, Context, ContextualAlias, RevisedContextualAlias};
-use sp_runtime::{transaction_validity::InvalidTransaction, DispatchError};
+use sp_runtime::{traits::Verify, transaction_validity::InvalidTransaction, DispatchError};
 use verifiable::GenerateVerifiable;
 
 const EXTENSION_VERSION: u8 = 0;
@@ -48,7 +49,7 @@ fn auth_context() -> Context {
 }
 
 fn attest_msg(who: u64, key: MemberOf<Test>) -> Vec<u8> {
-	[&MSG_PREFIX[..], &who.encode()[..], &key.encode()[..]].concat()
+	PeopleLitePallet::<Test>::registration_message(&who, &key)
 }
 
 fn secret_from_seed(seed: u8) -> SecretOfTest {
@@ -467,6 +468,384 @@ fn attest_rejects_duplicate_ring_vrf_key() {
 		assert_eq!(AttestationAllowance::<Test>::get(verifier), 1);
 		assert!(!LitePeople::<Test>::contains_key(candidate));
 	});
+}
+
+mod register_with_fee_tests {
+	use super::*;
+	use crate::weights::WeightInfo;
+
+	fn fund_lite_person_fee(account: u64) {
+		let _ = pallet_balances::Pallet::<Test>::make_free_balance_be(&account, 100);
+	}
+
+	fn register_with_fee(user: u64, seed: u8) -> SecretOfTest {
+		Pallet::<Test>::set_block_number(1);
+		create_lite_collection();
+		fund_lite_person_fee(user);
+		let secret = secret_from_seed(seed);
+		let ring_vrf_key = member_from_secret(&secret);
+		let proof = sign_attest_with_secret(&secret, user);
+		assert_ok!(PeopleLitePallet::<Test>::register_with_fee(
+			Some(user).into(),
+			ring_vrf_key,
+			proof,
+			None,
+		));
+		secret
+	}
+
+	fn consumer_registration_params(
+		account: u64,
+	) -> crate::types::LiteConsumerRegistrationParams<u64, sp_runtime::testing::UintAuthorityId> {
+		crate::types::LiteConsumerRegistrationParams {
+			signature: sp_runtime::testing::UintAuthorityId(account),
+			account,
+			identifier_key: [7; 65],
+			username: indiv_support::traits::Username::try_from(b"liteperson.1".to_vec())
+				.expect("valid username"),
+			reserved_username: None,
+		}
+	}
+
+	fn invalid_consumer_registration_params(
+		account: u64,
+	) -> crate::types::LiteConsumerRegistrationParams<u64, sp_runtime::testing::UintAuthorityId> {
+		let mut params = consumer_registration_params(account);
+		params.signature = sp_runtime::testing::UintAuthorityId(account.saturating_add(1));
+		params
+	}
+
+	#[test]
+	fn register_with_fee_transfers_funds_and_registers_lite_person() {
+		new_test_ext().execute_with(|| {
+			let candidate = 90;
+			let secret = register_with_fee(candidate, 14);
+			let ring_vrf_key = member_from_secret(&secret);
+
+			assert!(matches!(
+				LitePeople::<Test>::get(candidate),
+				Some(crate::types::LitePersonInfo {
+					ring_vrf_key: stored_key,
+					method: crate::RecognitionMethod::Fee,
+				}) if stored_key == ring_vrf_key
+			));
+			assert_eq!(pallet_balances::Pallet::<Test>::free_balance(candidate), 90);
+			assert_eq!(
+				pallet_balances::Pallet::<Test>::free_balance(
+					PeopleLitePallet::<Test>::lite_people_pot_id(),
+				),
+				LitePersonRegistrationFee::get(),
+			);
+			assert_eq!(pallet_balances::Pallet::<Test>::total_balance_on_hold(&candidate), 0);
+			assert_eq!(
+				mock_member_service_members(LITE_PEOPLE_MEMBER_IDENTIFIER),
+				vec![ring_vrf_key],
+			);
+			assert_eq!(Pallet::<Test>::account(candidate).sufficients, 1);
+			Pallet::<Test>::assert_last_event(
+				crate::Event::<Test>::PersonRegisteredWithFee { candidate }.into(),
+			);
+		});
+	}
+
+	#[test]
+	fn register_with_fee_requires_initialized_collection() {
+		new_test_ext().execute_with(|| {
+			let candidate = 91;
+			fund_lite_person_fee(candidate);
+			let secret = secret_from_seed(15);
+			let key = member_from_secret(&secret);
+
+			assert_noop!(
+				PeopleLitePallet::<Test>::register_with_fee(
+					Some(candidate).into(),
+					key,
+					sign_attest_with_secret(&secret, candidate),
+					None,
+				),
+				crate::Error::<Test>::LitePeopleCollectionNotCreated
+			);
+			assert!(LitePeople::<Test>::get(candidate).is_none());
+			assert_eq!(pallet_balances::Pallet::<Test>::free_balance(candidate), 100);
+		});
+	}
+
+	#[test]
+	fn register_with_fee_rejects_invalid_ownership_proof() {
+		new_test_ext().execute_with(|| {
+			create_lite_collection();
+			let candidate = 92;
+			fund_lite_person_fee(candidate);
+			let secret = secret_from_seed(16);
+			let wrong_secret = secret_from_seed(17);
+			let key = member_from_secret(&secret);
+
+			assert_noop!(
+				PeopleLitePallet::<Test>::register_with_fee(
+					Some(candidate).into(),
+					key,
+					sign_attest_with_secret(&wrong_secret, candidate),
+					None,
+				),
+				crate::Error::<Test>::InvalidProofOfOwnership
+			);
+			assert!(LitePeople::<Test>::get(candidate).is_none());
+		});
+	}
+
+	#[test]
+	fn register_with_fee_rejects_insufficient_funds() {
+		new_test_ext().execute_with(|| {
+			create_lite_collection();
+			let candidate = 93;
+			let secret = secret_from_seed(18);
+			let key = member_from_secret(&secret);
+
+			assert_noop!(
+				PeopleLitePallet::<Test>::register_with_fee(
+					Some(candidate).into(),
+					key,
+					sign_attest_with_secret(&secret, candidate),
+					None,
+				),
+				DispatchError::Arithmetic(sp_runtime::ArithmeticError::Underflow)
+			);
+			assert!(LitePeople::<Test>::get(candidate).is_none());
+			assert_eq!(Pallet::<Test>::account(candidate).sufficients, 0);
+		});
+	}
+
+	#[test]
+	fn register_with_fee_preserves_the_candidate_account() {
+		new_test_ext().execute_with(|| {
+			create_lite_collection();
+			let candidate = 105;
+			let fee = LitePersonRegistrationFee::get();
+			let _ = pallet_balances::Pallet::<Test>::make_free_balance_be(&candidate, fee);
+			let secret = secret_from_seed(28);
+
+			assert_noop!(
+				PeopleLitePallet::<Test>::register_with_fee(
+					Some(candidate).into(),
+					member_from_secret(&secret),
+					sign_attest_with_secret(&secret, candidate),
+					None,
+				),
+				DispatchError::Token(sp_runtime::TokenError::NotExpendable)
+			);
+			assert_eq!(pallet_balances::Pallet::<Test>::free_balance(candidate), fee);
+			assert_eq!(
+				pallet_balances::Pallet::<Test>::free_balance(
+					PeopleLitePallet::<Test>::lite_people_pot_id(),
+				),
+				0,
+			);
+		});
+	}
+
+	#[test]
+	fn register_with_fee_uses_the_current_fee_getter_value() {
+		new_test_ext().execute_with(|| {
+			create_lite_collection();
+			LitePersonRegistrationFee::set(&20);
+			let candidate = 106;
+			fund_lite_person_fee(candidate);
+			let secret = secret_from_seed(29);
+
+			assert_ok!(PeopleLitePallet::<Test>::register_with_fee(
+				Some(candidate).into(),
+				member_from_secret(&secret),
+				sign_attest_with_secret(&secret, candidate),
+				None,
+			));
+			assert_eq!(pallet_balances::Pallet::<Test>::free_balance(candidate), 80);
+			assert_eq!(
+				pallet_balances::Pallet::<Test>::free_balance(
+					PeopleLitePallet::<Test>::lite_people_pot_id(),
+				),
+				20,
+			);
+		});
+	}
+
+	#[test]
+	fn register_with_fee_rejects_registered_accounts_from_both_methods() {
+		new_test_ext().execute_with(|| {
+			let attested_candidate = 94;
+			register_lite_person(95, attested_candidate, 19);
+			fund_lite_person_fee(attested_candidate);
+			let deposit_secret = secret_from_seed(20);
+			assert_noop!(
+				PeopleLitePallet::<Test>::register_with_fee(
+					Some(attested_candidate).into(),
+					member_from_secret(&deposit_secret),
+					sign_attest_with_secret(&deposit_secret, attested_candidate),
+					None,
+				),
+				crate::Error::<Test>::AlreadyRegistered
+			);
+
+			let deposited_candidate = 96;
+			register_with_fee(deposited_candidate, 21);
+			let attested_secret = secret_from_seed(22);
+			assert_noop!(
+				PeopleLitePallet::<Test>::attest(
+					Some(97).into(),
+					deposited_candidate,
+					sp_runtime::testing::UintAuthorityId(deposited_candidate),
+					member_from_secret(&attested_secret),
+					sign_attest_with_secret(&attested_secret, deposited_candidate),
+					None,
+				),
+				crate::Error::<Test>::AlreadyRegistered
+			);
+		});
+	}
+
+	#[test]
+	fn register_with_fee_rejects_ring_key_already_in_use() {
+		new_test_ext().execute_with(|| {
+			let original_candidate = 98;
+			let secret = register_lite_person(99, original_candidate, 23);
+			let candidate = 100;
+			fund_lite_person_fee(candidate);
+			let key = member_from_secret(&secret);
+
+			assert_noop!(
+				PeopleLitePallet::<Test>::register_with_fee(
+					Some(candidate).into(),
+					key,
+					sign_attest_with_secret(&secret, candidate),
+					None,
+				),
+				crate::Error::<Test>::KeyAlreadyInUse
+			);
+			assert!(LitePeople::<Test>::get(candidate).is_none());
+		});
+	}
+
+	#[test]
+	fn register_with_fee_forwards_valid_consumer_registration() {
+		new_test_ext().execute_with(|| {
+			Pallet::<Test>::set_block_number(1);
+			create_lite_collection();
+			let candidate = 101;
+			fund_lite_person_fee(candidate);
+			let secret = secret_from_seed(24);
+			let call = RuntimeCall::PeopleLite(crate::Call::<Test>::register_with_fee {
+				ring_vrf_key: member_from_secret(&secret),
+				proof_of_ownership: sign_attest_with_secret(&secret, candidate),
+				consumer_registration: Some(consumer_registration_params(candidate)),
+			});
+
+			assert_ok!(exec_signed_tx(candidate, call));
+			assert_eq!(mock_registered_consumers(), vec![candidate]);
+			Pallet::<Test>::assert_last_event(
+				crate::Event::<Test>::ConsumerRegistered { account: candidate }.into(),
+			);
+		});
+	}
+
+	#[test]
+	fn register_with_fee_rejects_invalid_consumer_registration_signature() {
+		new_test_ext().execute_with(|| {
+			create_lite_collection();
+			let candidate = 102;
+			fund_lite_person_fee(candidate);
+			let secret = secret_from_seed(25);
+
+			assert_noop!(
+				PeopleLitePallet::<Test>::register_with_fee(
+					Some(candidate).into(),
+					member_from_secret(&secret),
+					sign_attest_with_secret(&secret, candidate),
+					Some(invalid_consumer_registration_params(candidate)),
+				),
+				crate::Error::<Test>::InvalidAttestationSignature
+			);
+			assert_eq!(mock_registered_consumers(), Vec::<u64>::new());
+			assert!(LitePeople::<Test>::get(candidate).is_none());
+		});
+	}
+
+	#[test]
+	fn register_with_fee_rejects_mismatched_consumer_registration_account() {
+		new_test_ext().execute_with(|| {
+			create_lite_collection();
+			let candidate = 103;
+			let consumer = 104;
+			fund_lite_person_fee(candidate);
+			let secret = secret_from_seed(26);
+			let params = consumer_registration_params(consumer);
+
+			assert!(params
+				.signature
+				.verify(&params.signing_payload(&candidate)[..], &params.account));
+			assert_noop!(
+				PeopleLitePallet::<Test>::register_with_fee(
+					Some(candidate).into(),
+					member_from_secret(&secret),
+					sign_attest_with_secret(&secret, candidate),
+					Some(params),
+				),
+				crate::Error::<Test>::InvalidConsumerRegistrationAccount
+			);
+			assert_eq!(mock_registered_consumers(), Vec::<u64>::new());
+			assert!(LitePeople::<Test>::get(candidate).is_none());
+			assert_eq!(pallet_balances::Pallet::<Test>::free_balance(candidate), 100);
+		});
+	}
+
+	#[test]
+	fn register_with_fee_rolls_back_when_consumer_registration_fails() {
+		new_test_ext().execute_with(|| {
+			create_lite_collection();
+			let candidate = 103;
+			fund_lite_person_fee(candidate);
+			let secret = secret_from_seed(26);
+			mock_consumer_registrar_fail_next();
+
+			assert_noop!(
+				PeopleLitePallet::<Test>::register_with_fee(
+					Some(candidate).into(),
+					member_from_secret(&secret),
+					sign_attest_with_secret(&secret, candidate),
+					Some(consumer_registration_params(candidate)),
+				),
+				DispatchError::Other("mock consumer registration failed")
+			);
+			assert_eq!(mock_registered_consumers(), Vec::<u64>::new());
+			assert!(LitePeople::<Test>::get(candidate).is_none());
+			assert_eq!(pallet_balances::Pallet::<Test>::free_balance(candidate), 100);
+		});
+	}
+
+	#[test]
+	fn register_with_fee_charges_weight_for_consumer_registration() {
+		new_test_ext().execute_with(|| {
+			let candidate = 104;
+			let secret = secret_from_seed(27);
+			let without_consumer = crate::Call::<Test>::register_with_fee {
+				ring_vrf_key: member_from_secret(&secret),
+				proof_of_ownership: sign_attest_with_secret(&secret, candidate),
+				consumer_registration: None,
+			};
+			let with_consumer = crate::Call::<Test>::register_with_fee {
+				ring_vrf_key: member_from_secret(&secret),
+				proof_of_ownership: sign_attest_with_secret(&secret, candidate),
+				consumer_registration: Some(consumer_registration_params(candidate)),
+			};
+
+			let without_consumer_weight = without_consumer.get_dispatch_info().call_weight;
+			let with_consumer_weight = with_consumer.get_dispatch_info().call_weight;
+			let registration_weight = <Test as crate::Config>::WeightInfo::register_with_fee();
+			let consumer_weight = <Test as crate::Config>::WeightInfo::register_lite_consumer();
+
+			assert_eq!(without_consumer_weight, registration_weight);
+			assert_eq!(with_consumer_weight, registration_weight.saturating_add(consumer_weight));
+			assert!(without_consumer_weight.all_lt(with_consumer_weight));
+		});
+	}
 }
 
 #[test]

--- a/pallets/people-lite/src/types.rs
+++ b/pallets/people-lite/src/types.rs
@@ -36,6 +36,8 @@ pub type SignatureOf<T> = <CryptoOf<T> as GenerateVerifiable>::Signature;
 pub enum RecognitionMethod<Account> {
 	/// User has a unique device, corroborated by the attester.
 	UniqueDevice(Account),
+	/// User paid the registration fee without a unique-device attestation.
+	Fee,
 	// Voucher(PersonalId)
 }
 

--- a/pallets/people-lite/src/weights.rs
+++ b/pallets/people-lite/src/weights.rs
@@ -62,6 +62,7 @@ pub trait WeightInfo {
 	fn clear_attestation_allowance() -> Weight;
 	fn register_lite_consumer() -> Weight;
 	fn attest() -> Weight;
+	fn register_with_fee() -> Weight;
 	fn dispatch_as_signer() -> Weight;
 	fn set_alias_account() -> Weight;
 	fn unset_alias_account() -> Weight;
@@ -204,6 +205,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(1_371_129_000, 11671)
 			.saturating_add(T::DbWeight::get().reads(9_u64))
 			.saturating_add(T::DbWeight::get().writes(6_u64))
+	}
+	fn register_with_fee() -> Weight {
+		Weight::from_parts(1_374_397_000, 11671)
+			.saturating_add(T::DbWeight::get().reads(11_u64))
+			.saturating_add(T::DbWeight::get().writes(8_u64))
 	}
 	fn dispatch_as_signer() -> Weight {
 		// Proof Size summary in bytes:
@@ -411,6 +417,11 @@ impl WeightInfo for () {
 		Weight::from_parts(1_371_129_000, 11671)
 			.saturating_add(RocksDbWeight::get().reads(9_u64))
 			.saturating_add(RocksDbWeight::get().writes(6_u64))
+	}
+	fn register_with_fee() -> Weight {
+		Weight::from_parts(1_374_397_000, 11671)
+			.saturating_add(RocksDbWeight::get().reads(11_u64))
+			.saturating_add(RocksDbWeight::get().writes(8_u64))
 	}
 	fn dispatch_as_signer() -> Weight {
 		// Proof Size summary in bytes:

--- a/pallets/resources/Cargo.toml
+++ b/pallets/resources/Cargo.toml
@@ -36,6 +36,7 @@ indiv-pallet-members = { workspace = true }
 verifiable = { workspace = true, features = ["mock"] }
 parking_lot = { workspace = true }
 frame-executive = { workspace = true }
+pallet-balances = { workspace = true }
 
 [features]
 default = ["std"]
@@ -51,6 +52,7 @@ std = [
 	"indiv-pallet-people/std",
 	"indiv-support/std",
 	"log/std",
+	"pallet-balances/std",
 	"scale-info/std",
 	"sp-core/std",
 	"sp-io/std",
@@ -67,6 +69,7 @@ runtime-benchmarks = [
 	"indiv-pallet-people-lite/runtime-benchmarks",
 	"indiv-pallet-people/runtime-benchmarks",
 	"indiv-support/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
@@ -77,5 +80,6 @@ try-runtime = [
 	"indiv-pallet-members/try-runtime",
 	"indiv-pallet-people-lite/try-runtime",
 	"indiv-pallet-people/try-runtime",
+	"pallet-balances/try-runtime",
 	"sp-runtime/try-runtime",
 ]

--- a/pallets/resources/src/mock.rs
+++ b/pallets/resources/src/mock.rs
@@ -26,6 +26,7 @@ use frame_support::{
 	parameter_types,
 	storage::with_transaction,
 	traits::{OffchainWorker, OriginTrait},
+	PalletId,
 };
 use frame_system::{
 	offchain::{CreateAuthorizedTransaction, CreateBare, CreateTransaction, CreateTransactionBase},
@@ -247,6 +248,7 @@ frame_support::construct_runtime!(
 		Resources: crate,
 		People: indiv_pallet_people,
 		PeopleLite: indiv_pallet_people_lite,
+		Balances: pallet_balances,
 	}
 );
 
@@ -269,13 +271,18 @@ impl frame_system::Config for Test {
 	type BlockHashCount = ConstUint<250>;
 	type Version = ();
 	type PalletInfo = PalletInfo;
-	type AccountData = ();
+	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
 	type SS58Prefix = ConstUint<42>;
 	type OnSetCode = ();
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Test {
+	type AccountStore = System;
 }
 
 impl indiv_pallet_chunks_manager::Config for Test {
@@ -417,6 +424,9 @@ impl indiv_pallet_people_lite::BenchmarkHelper<AccountId32, AccountAuthority> fo
 
 impl indiv_pallet_people_lite::Config for Test {
 	type WeightInfo = ();
+	type Currency = Balances;
+	type PotId = LitePeoplePotId;
+	type RegistrationFee = LitePersonRegistrationFee;
 	type Suffix = NetworkSuffix;
 	type AccountContexts = ();
 	type AttestationAllowanceManager = EnsureRoot<Self::AccountId>;
@@ -445,6 +455,8 @@ impl indiv_pallet_people::Config for Test {
 }
 
 parameter_types! {
+	pub storage LitePersonRegistrationFee: u64 = 10;
+	pub const LitePeoplePotId: PalletId = PalletId(*b"plitefee");
 	pub const NetworkSuffix: &'static [u8] = b"paseo";
 	pub LitePersonStatementLimit: sp_statement_store::StatementAllowance = sp_statement_store::StatementAllowance {
 		max_size: 4 * 1024, // 4 KiB

--- a/runtimes/next-people-paseo/src/integration_tests/lite_people_free_tx.rs
+++ b/runtimes/next-people-paseo/src/integration_tests/lite_people_free_tx.rs
@@ -15,7 +15,44 @@
 // limitations under the License.
 
 use super::*;
-use frame_support::assert_ok;
+use crate::{
+	parameters::{dynamic_params::lite_personhood, LitePersonRegistrationFee, RuntimeParameters},
+	Parameters,
+};
+use frame_support::{assert_noop, assert_ok};
+
+fn fee_registration_payload(
+	lite_account: &AccountId32,
+	seed: [u8; 32],
+) -> (<Crypto as GenerateVerifiable>::Member, <Crypto as GenerateVerifiable>::Signature) {
+	let ring_secret = Crypto::new_secret(seed);
+	let ring_member = Crypto::member_from_secret(&ring_secret);
+	let message = lite_account.using_encoded(|account_bytes| {
+		ring_member.using_encoded(|ring_bytes| {
+			[&indiv_pallet_people_lite::MSG_PREFIX[..], account_bytes, ring_bytes].concat()
+		})
+	});
+	let proof = Crypto::sign(&ring_secret, &message)
+		.expect("ring key can sign the fee registration payload");
+	(ring_member, proof)
+}
+
+fn consumer_registration_params(
+	lite_account: &AccountId32,
+	lite_pair: &sr25519::Pair,
+	verifier: &AccountId32,
+) -> indiv_pallet_people_lite::types::LiteConsumerRegistrationParams<AccountId32, MultiSignature> {
+	let mut params = indiv_pallet_people_lite::types::LiteConsumerRegistrationParams {
+		signature: MultiSignature::from(lite_pair.sign(b"placeholder")),
+		account: lite_account.clone(),
+		identifier_key: [7; 65],
+		username: indiv_support::traits::Username::try_from(b"liteperson.12".to_vec())
+			.expect("valid username"),
+		reserved_username: None,
+	};
+	params.signature = MultiSignature::from(lite_pair.sign(&params.signing_payload(verifier)));
+	params
+}
 
 fn register_lite_person(
 	attester: &AccountId32,
@@ -45,6 +82,115 @@ fn register_lite_person(
 	));
 
 	ring_secret
+}
+
+#[test]
+fn fee_registration_transfers_native_balance_to_the_pallet_pot() {
+	new_test_ext().execute_with(|| {
+		let lite_pair = sr25519::Pair::from_seed(&[78u8; 32]);
+		let lite_account = pair_to_account_id(&lite_pair);
+		let (ring_member, proof) = fee_registration_payload(&lite_account, [43u8; 32]);
+		let fee = LitePersonRegistrationFee::get();
+		let required_balance = fee.saturating_add(Balances::minimum_balance());
+		let pot = indiv_pallet_people_lite::Pallet::<Runtime>::lite_people_pot_id();
+
+		Balances::set_balance(&lite_account, required_balance);
+		assert_eq!(Balances::free_balance(&pot), 0);
+
+		assert_ok!(indiv_pallet_people_lite::Pallet::<Runtime>::register_with_fee(
+			RuntimeOrigin::signed(lite_account.clone()),
+			ring_member,
+			proof,
+			None,
+		));
+
+		assert!(matches!(
+			indiv_pallet_people_lite::LitePeople::<Runtime>::get(&lite_account)
+				.expect("candidate is registered")
+				.method,
+			indiv_pallet_people_lite::types::RecognitionMethod::Fee,
+		));
+		assert_eq!(Balances::free_balance(&lite_account), Balances::minimum_balance());
+		assert_eq!(Balances::free_balance(&pot), fee);
+		assert_eq!(Balances::total_balance_on_hold(&lite_account), 0);
+	});
+}
+
+#[test]
+fn root_parameter_update_changes_the_next_registration_fee() {
+	new_test_ext().execute_with(|| {
+		let updated_fee = LitePersonRegistrationFee::get().saturating_mul(2);
+		assert_ok!(Parameters::set_parameter(
+			RuntimeOrigin::root(),
+			RuntimeParameters::LitePersonhood(
+				(lite_personhood::RegistrationFee, updated_fee).into()
+			),
+		));
+
+		let lite_pair = sr25519::Pair::from_seed(&[79u8; 32]);
+		let lite_account = pair_to_account_id(&lite_pair);
+		let (ring_member, proof) = fee_registration_payload(&lite_account, [44u8; 32]);
+		let pot = indiv_pallet_people_lite::Pallet::<Runtime>::lite_people_pot_id();
+
+		Balances::set_balance(
+			&lite_account,
+			updated_fee.saturating_add(Balances::minimum_balance()),
+		);
+		assert_ok!(indiv_pallet_people_lite::Pallet::<Runtime>::register_with_fee(
+			RuntimeOrigin::signed(lite_account.clone()),
+			ring_member,
+			proof,
+			None,
+		));
+		assert_eq!(Balances::free_balance(&lite_account), Balances::minimum_balance());
+		assert_eq!(Balances::free_balance(&pot), updated_fee);
+	});
+}
+
+#[test]
+fn fee_registration_verifies_consumer_signature_with_the_candidate_as_verifier() {
+	new_test_ext().execute_with(|| {
+		let lite_pair = sr25519::Pair::from_seed(&[80u8; 32]);
+		let lite_account = pair_to_account_id(&lite_pair);
+		let (ring_member, proof) = fee_registration_payload(&lite_account, [45u8; 32]);
+		let fee = LitePersonRegistrationFee::get();
+
+		Balances::set_balance(&lite_account, fee.saturating_add(Balances::minimum_balance()));
+		assert_ok!(indiv_pallet_people_lite::Pallet::<Runtime>::register_with_fee(
+			RuntimeOrigin::signed(lite_account.clone()),
+			ring_member,
+			proof,
+			Some(consumer_registration_params(&lite_account, &lite_pair, &lite_account)),
+		));
+		assert!(indiv_pallet_resources::Consumers::<Runtime>::contains_key(&lite_account));
+	});
+}
+
+#[test]
+fn fee_registration_rejects_consumer_signature_for_a_different_verifier() {
+	new_test_ext().execute_with(|| {
+		let lite_pair = sr25519::Pair::from_seed(&[81u8; 32]);
+		let lite_account = pair_to_account_id(&lite_pair);
+		let wrong_verifier = pair_to_account_id(&sr25519::Pair::from_seed(&[82u8; 32]));
+		let (ring_member, proof) = fee_registration_payload(&lite_account, [46u8; 32]);
+		let fee = LitePersonRegistrationFee::get();
+		let required_balance = fee.saturating_add(Balances::minimum_balance());
+		let pot = indiv_pallet_people_lite::Pallet::<Runtime>::lite_people_pot_id();
+
+		Balances::set_balance(&lite_account, required_balance);
+		assert_noop!(
+			indiv_pallet_people_lite::Pallet::<Runtime>::register_with_fee(
+				RuntimeOrigin::signed(lite_account.clone()),
+				ring_member,
+				proof,
+				Some(consumer_registration_params(&lite_account, &lite_pair, &wrong_verifier)),
+			),
+			indiv_pallet_people_lite::Error::<Runtime>::InvalidAttestationSignature,
+		);
+		assert!(!indiv_pallet_people_lite::LitePeople::<Runtime>::contains_key(&lite_account));
+		assert_eq!(Balances::free_balance(&lite_account), required_balance);
+		assert_eq!(Balances::free_balance(&pot), 0);
+	});
 }
 
 fn build_lite_person_signed_ext(who: &sr25519::Pair, call: RuntimeCall) -> UncheckedExtrinsic {

--- a/runtimes/next-people-paseo/src/parameters.rs
+++ b/runtimes/next-people-paseo/src/parameters.rs
@@ -98,6 +98,15 @@ pub mod dynamic_params {
 		pub static PrizeSource: sp_runtime::AccountId32 =
 			PalletId(*b"pop/pads").into_account_truncating();
 	}
+
+	/// Lite-person registration pricing.
+	#[dynamic_pallet_params]
+	#[codec(index = 3)]
+	pub mod lite_personhood {
+		/// Non-refundable native fee required to register as a lite person.
+		#[codec(index = 0)]
+		pub static RegistrationFee: Balance = 75 * UNITS;
+	}
 }
 
 // `pallet_parameters` validates only the origin of an update, never the stored value, and the
@@ -182,6 +191,9 @@ pub type LongTermStorageAllowanceForPeople =
 	dynamic_params::bulletin_storage::LongTermStorageAllowanceForPeople;
 pub type LongTermStorageAllowanceForLitePeople =
 	dynamic_params::bulletin_storage::LongTermStorageAllowanceForLitePeople;
+
+/// Fee required to register as a lite person without device attestation.
+pub type LitePersonRegistrationFee = dynamic_params::lite_personhood::RegistrationFee;
 
 /// Any account is a valid prize source, so the value is read unclamped.
 pub type PeopleAirdropsPrizeSource = dynamic_params::people_airdrops::PrizeSource;

--- a/runtimes/next-people-paseo/src/people.rs
+++ b/runtimes/next-people-paseo/src/people.rs
@@ -25,6 +25,7 @@ use frame_support::{
 		fungible::{HoldConsideration, ItemOf},
 		ConstU128, ConstU32, ConstU8, ConstUint, Footprint, Get, LinearStoragePrice, Randomness,
 	},
+	PalletId,
 };
 #[cfg(feature = "runtime-benchmarks")]
 use indiv_support::traits::PersonalId;
@@ -49,13 +50,14 @@ use xcm::v5::{Location, WeightLimit};
 
 use crate::{
 	parameters::{
-		AccountsApiAllowance, LiteNotificationSlotsPerPeriod, LitePersonStatementLimit,
-		LiteStmtStoreSlotsPerPeriod, LongTermStorageAllowanceForLitePeople,
-		LongTermStorageAllowanceForPeople, LongTermStorageClaimsPerPeriod,
-		LongTermStorageCleanupLimit, LongTermStorageGraceWindow, LongTermStoragePeriodDuration,
-		NotificationAllowance, NotificationPeriodDuration, NotificationSlotsPerPeriod,
-		PeopleAirdropsPrizeSource, PersonStatementLimit, StmtStoreCleanupLimit,
-		StmtStoreGraceWindow, StmtStoreReplacementCooldown, StmtStoreSlotsPerPeriod,
+		AccountsApiAllowance, LiteNotificationSlotsPerPeriod, LitePersonRegistrationFee,
+		LitePersonStatementLimit, LiteStmtStoreSlotsPerPeriod,
+		LongTermStorageAllowanceForLitePeople, LongTermStorageAllowanceForPeople,
+		LongTermStorageClaimsPerPeriod, LongTermStorageCleanupLimit, LongTermStorageGraceWindow,
+		LongTermStoragePeriodDuration, NotificationAllowance, NotificationPeriodDuration,
+		NotificationSlotsPerPeriod, PeopleAirdropsPrizeSource, PersonStatementLimit,
+		StmtStoreCleanupLimit, StmtStoreGraceWindow, StmtStoreReplacementCooldown,
+		StmtStoreSlotsPerPeriod,
 	},
 	paseo_constants::{CENTS, UNITS},
 };
@@ -139,6 +141,8 @@ parameter_types! {
 		indiv_support::traits::RingExponent::R2e9;
 	/// Onboarding size for lite people collection.
 	pub const LitePeopleOnboardingSize: u32 = 3;
+	/// Pallet identifier used to derive the account that receives lite-person registration fees.
+	pub const LitePeoplePotId: PalletId = PalletId(*b"plitefee");
 	/// The page size for chunks manager.
 	pub const ChunkPageSize: u32 = 255;
 	/// Self-inclusion delay: 60 minutes.
@@ -1229,6 +1233,9 @@ impl indiv_pallet_people_lite::BenchmarkHelper<AccountId, Signature> for PeopleL
 
 impl indiv_pallet_people_lite::Config for Runtime {
 	type WeightInfo = weights::indiv_pallet_people_lite::WeightInfo<Runtime>;
+	type Currency = Balances;
+	type PotId = LitePeoplePotId;
+	type RegistrationFee = LitePersonRegistrationFee;
 	type Suffix = NetworkSuffix;
 	type AttestationAllowanceManager = EnsureRoot<Self::AccountId>;
 	type MemberService = Members;

--- a/runtimes/next-people-paseo/src/weights/indiv_pallet_people_lite.rs
+++ b/runtimes/next-people-paseo/src/weights/indiv_pallet_people_lite.rs
@@ -194,6 +194,13 @@ impl<T: frame_system::Config> indiv_pallet_people_lite::WeightInfo for WeightInf
 			.saturating_add(T::DbWeight::get().reads(9))
 			.saturating_add(T::DbWeight::get().writes(6))
 	}
+	// Placeholder for fee-to-pot registration. The benchmark bot regenerates this after push.
+	fn register_with_fee() -> Weight {
+		Weight::from_parts(1_374_450_000, 0)
+			.saturating_add(Weight::from_parts(0, 11671))
+			.saturating_add(T::DbWeight::get().reads(11))
+			.saturating_add(T::DbWeight::get().writes(8))
+	}
 	fn dispatch_as_signer() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`


### PR DESCRIPTION
Ported from private Individuality repository: https://github.com/paritytech/individuality/commit/be61b7720e5345afff53f28b924f8bc129938e24

PR previously approved and merged: https://github.com/paritytech/individuality/pull/1252 

Individuality added fee-backed lite-person registration in https://github.com/paritytech/individuality/commit/be61b7720e5345afff53f28b924f8bc129938e24. This community repository does not yet contain that change, so its People Paseo runtime lacks the same non-refundable registration path and dynamic pricing.

This ports the source commit onto the current community `main`. `register_with_fee` transfers the configured native fee to the people-lite pallet pot with `Preservation::Preserve`, records fee recognition and validates optional consumer registration with the candidate as verifier.

## Changes

- Add `register_with_fee(origin, ring_vrf_key, proof_of_ownership, consumer_registration)` and the `PersonRegisteredWithFee` event.
- Add `Currency`, `PotId` and `RegistrationFee` configuration types, the derived fee-pot account and `RecognitionMethod::Fee`.
- Add the dynamic `LitePersonRegistrationFee` parameter with a default of `75 * UNITS` and wire it into People Paseo.
- Add fee-registration benchmarking, pallet weights and the documented placeholder runtime weight pending benchmark-bot regeneration.
- Add pallet and runtime tests for fee transfer, preserve semantics, dynamic fee updates, ring VRF ownership and valid and invalid consumer signatures.