### PR TITLE
fix(people-lite): add minimum registration fee

### DIFF
--- a/runtimes/next-people-paseo/src/integration_tests/lite_people_free_tx.rs
+++ b/runtimes/next-people-paseo/src/integration_tests/lite_people_free_tx.rs
@@ -148,6 +148,24 @@ fn root_parameter_update_changes_the_next_registration_fee() {
 }
 
 #[test]
+fn root_parameter_update_below_the_existential_deposit_uses_the_minimum_fee() {
+	new_test_ext().execute_with(|| {
+		let minimum_fee = ExistentialDeposit::get();
+		assert!(minimum_fee > 0);
+		let updated_fee = minimum_fee.saturating_sub(1);
+		assert_ok!(Parameters::set_parameter(
+			RuntimeOrigin::root(),
+			RuntimeParameters::LitePersonhood(
+				(lite_personhood::RegistrationFee, updated_fee).into()
+			),
+		));
+
+		assert_eq!(lite_personhood::RegistrationFee::get(), updated_fee);
+		assert_eq!(LitePersonRegistrationFee::get(), minimum_fee);
+	});
+}
+
+#[test]
 fn fee_registration_verifies_consumer_signature_with_the_candidate_as_verifier() {
 	new_test_ext().execute_with(|| {
 		let lite_pair = sr25519::Pair::from_seed(&[80u8; 32]);

--- a/runtimes/next-people-paseo/src/parameters.rs
+++ b/runtimes/next-people-paseo/src/parameters.rs
@@ -4,7 +4,7 @@
 
 //! Governance-mutable Individuality runtime parameters.
 
-use crate::*;
+use crate::{ExistentialDeposit, *};
 use frame_support::{
 	dynamic_params::{dynamic_pallet_params, dynamic_params},
 	traits::{ConstU32, EnsureOrigin, EnsureOriginWithArg},
@@ -12,7 +12,7 @@ use frame_support::{
 };
 use indiv_pallet_resources::types::LongTermStorageAllocation;
 use indiv_support::parameters::{
-	AtLeastOne, AtMost, BenchmarkMax, SaturatingSubOne, StatementAllowanceGetter,
+	AtLeast, AtLeastOne, AtMost, BenchmarkMax, SaturatingSubOne, StatementAllowanceGetter,
 	StatementAllowanceParameter,
 };
 use sp_runtime::traits::AccountIdConversion;
@@ -193,7 +193,11 @@ pub type LongTermStorageAllowanceForLitePeople =
 	dynamic_params::bulletin_storage::LongTermStorageAllowanceForLitePeople;
 
 /// Fee required to register as a lite person without device attestation.
-pub type LitePersonRegistrationFee = dynamic_params::lite_personhood::RegistrationFee;
+///
+/// A stored value below the existential deposit cannot make registration free or prevent the fee
+/// pot account from existing.
+pub type LitePersonRegistrationFee =
+	AtLeast<dynamic_params::lite_personhood::RegistrationFee, ExistentialDeposit>;
 
 /// Any account is a valid prize source, so the value is read unclamped.
 pub type PeopleAirdropsPrizeSource = dynamic_params::people_airdrops::PrizeSource;

--- a/support/src/parameters.rs
+++ b/support/src/parameters.rs
@@ -68,6 +68,14 @@ impl<Value: Ord, Inner: Get<Value>, Maximum: Get<Value>> Get<Value> for AtMost<I
 	}
 }
 
+/// Clamps the inner value to at least the value supplied by `Minimum`.
+pub struct AtLeast<Inner, Minimum>(PhantomData<(Inner, Minimum)>);
+impl<Value: Ord, Inner: Get<Value>, Minimum: Get<Value>> Get<Value> for AtLeast<Inner, Minimum> {
+	fn get() -> Value {
+		Inner::get().max(Minimum::get())
+	}
+}
+
 /// Subtracts one with saturation from a `u32` getter.
 pub struct SaturatingSubOne<Inner>(PhantomData<Inner>);
 impl<Inner: Get<u32>> Get<u32> for SaturatingSubOne<Inner> {
@@ -144,6 +152,12 @@ mod tests {
 	fn at_most_preserves_in_range_values_and_clamps_the_maximum() {
 		assert_eq!(<AtMost<ConstU32<10>, ConstU32<20>> as Get<u32>>::get(), 10);
 		assert_eq!(<AtMost<ConstU32<30>, ConstU32<20>> as Get<u32>>::get(), 20);
+	}
+
+	#[test]
+	fn at_least_preserves_in_range_values_and_clamps_the_minimum() {
+		assert_eq!(<AtLeast<ConstU32<20>, ConstU32<10>> as Get<u32>>::get(), 20);
+		assert_eq!(<AtLeast<ConstU32<10>, ConstU32<20>> as Get<u32>>::get(), 20);
 	}
 
 	#[test]


### PR DESCRIPTION
Closes #15

The dynamic lite-person fee can be set below the existential deposit because parameter updates validate only their origin. A value below the minimum can make fee registration effectively free or leave the fee-pot account unfunded.

This stacks on #16 and clamps every `LitePersonRegistrationFee` read to at least `ExistentialDeposit`, while keeping the raw governance-set dynamic parameter observable.

## Changes

- Add reusable `AtLeast<Inner, Minimum>` and helper coverage.
- Wrap `LitePersonRegistrationFee` with `AtLeast<..., ExistentialDeposit>`.
- Add a runtime test that stores a fee below the existential deposit and observes the clamped public getter.