### PR TITLE
fix(people-lite): reject alias accounts in attest

### DIFF
--- a/pallets/people-lite/src/lib.rs
+++ b/pallets/people-lite/src/lib.rs
@@ -377,6 +377,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let verifier = ensure_signed(origin)?;
 			ensure!(!LitePeople::<T>::contains_key(&candidate), Error::<T>::AlreadyRegistered);
+			ensure!(!AccountToAlias::<T>::contains_key(&candidate), Error::<T>::AccountInUse);
 			ensure!(
 				T::MemberService::member_status(LITE_PEOPLE_MEMBER_IDENTIFIER, &ring_vrf_key)
 					.is_none(),

--- a/pallets/people-lite/src/tests.rs
+++ b/pallets/people-lite/src/tests.rs
@@ -440,6 +440,36 @@ fn attest_rejects_already_registered_candidate() {
 }
 
 #[test]
+fn attest_rejects_candidate_account_bound_to_alias() {
+	new_test_ext().execute_with(|| {
+		let lite_account = 72;
+		let alias_account = 73;
+		let alias_secret = register_lite_person(74, lite_account, 8);
+		let (_, alias) = establish_alias(&alias_secret, alias_account);
+		assert_eq!(AccountToAlias::<Test>::get(alias_account), Some(alias));
+
+		let verifier = 75;
+		AttestationAllowance::<Test>::insert(verifier, 1);
+		let candidate_secret = secret_from_seed(9);
+		let ring_vrf_key = member_from_secret(&candidate_secret);
+
+		assert_noop!(
+			PeopleLitePallet::<Test>::attest(
+				Some(verifier).into(),
+				alias_account,
+				sp_runtime::testing::UintAuthorityId(alias_account),
+				ring_vrf_key,
+				sign_attest_with_secret(&candidate_secret, alias_account),
+				None,
+			),
+			crate::Error::<Test>::AccountInUse
+		);
+		assert_eq!(AttestationAllowance::<Test>::get(verifier), 1);
+		assert!(!LitePeople::<Test>::contains_key(alias_account));
+	});
+}
+
+#[test]
 fn attest_rejects_duplicate_ring_vrf_key() {
 	new_test_ext().execute_with(|| {
 		let original_verifier = 80;


### PR DESCRIPTION
Closes #5

`attest` only rejected accounts registered as lite people, so an account already bound to a lite alias could also become a canonical lite person.

The call now rejects alias-bound candidates with `AccountInUse` before registration. A regression test establishes a real alias binding and verifies that attestation leaves the binding and allowance unchanged.

## Changes

- Add the `AccountToAlias` gate to `PeopleLite::attest`.
- Add a regression test for an alias-bound candidate.