### PR TITLE
fix(people-lite): reject alias accounts in attest

### DIFF
--- a/pallets/people-lite/src/lib.rs
+++ b/pallets/people-lite/src/lib.rs
@@ -559,7 +559,7 @@ pub mod pallet {
 				T::AccountContexts::contains(&rev_ca.ca.context),
 				Error::<T>::InvalidAliasContext
 			);
-			ensure!(!LitePeople::<T>::contains_key(&account), Error::<T>::AccountInUse);
+			ensure!(!LitePeople::<T>::contains_key(&account), Error::<T>::AlreadyRegistered);
 
 			let old_account = AliasToAccount::<T>::get(&rev_ca.ca);
 			let old_rev_ca = old_account.as_ref().and_then(AccountToAlias::<T>::get);

--- a/pallets/people-lite/src/lib.rs
+++ b/pallets/people-lite/src/lib.rs
@@ -461,6 +461,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let candidate = ensure_signed(origin)?;
 			ensure!(!LitePeople::<T>::contains_key(&candidate), Error::<T>::AlreadyRegistered);
+			ensure!(!AccountToAlias::<T>::contains_key(&candidate), Error::<T>::AccountInUse);
 			ensure!(
 				T::MemberService::member_status(LITE_PEOPLE_MEMBER_IDENTIFIER, &ring_vrf_key)
 					.is_none(),

--- a/pallets/people-lite/src/lib.rs
+++ b/pallets/people-lite/src/lib.rs
@@ -377,6 +377,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let verifier = ensure_signed(origin)?;
 			ensure!(!LitePeople::<T>::contains_key(&candidate), Error::<T>::AlreadyRegistered);
+			ensure!(!AccountToAlias::<T>::contains_key(&candidate), Error::<T>::AccountInUse);
 			ensure!(
 				T::MemberService::member_status(LITE_PEOPLE_MEMBER_IDENTIFIER, &ring_vrf_key)
 					.is_none(),

--- a/pallets/people-lite/src/tests.rs
+++ b/pallets/people-lite/src/tests.rs
@@ -440,6 +440,36 @@ fn attest_rejects_already_registered_candidate() {
 }
 
 #[test]
+fn attest_rejects_candidate_account_bound_to_alias() {
+	new_test_ext().execute_with(|| {
+		let lite_account = 72;
+		let alias_account = 73;
+		let alias_secret = register_lite_person(74, lite_account, 8);
+		let (_, alias) = establish_alias(&alias_secret, alias_account);
+		assert_eq!(AccountToAlias::<Test>::get(alias_account), Some(alias));
+
+		let verifier = 75;
+		AttestationAllowance::<Test>::insert(verifier, 1);
+		let candidate_secret = secret_from_seed(9);
+		let ring_vrf_key = member_from_secret(&candidate_secret);
+
+		assert_noop!(
+			PeopleLitePallet::<Test>::attest(
+				Some(verifier).into(),
+				alias_account,
+				sp_runtime::testing::UintAuthorityId(alias_account),
+				ring_vrf_key,
+				sign_attest_with_secret(&candidate_secret, alias_account),
+				None,
+			),
+			crate::Error::<Test>::AccountInUse
+		);
+		assert_eq!(AttestationAllowance::<Test>::get(verifier), 1);
+		assert!(!LitePeople::<Test>::contains_key(alias_account));
+	});
+}
+
+#[test]
 fn attest_rejects_duplicate_ring_vrf_key() {
 	new_test_ext().execute_with(|| {
 		let original_verifier = 80;

--- a/pallets/people-lite/src/tests.rs
+++ b/pallets/people-lite/src/tests.rs
@@ -733,6 +733,37 @@ mod register_with_fee_tests {
 	}
 
 	#[test]
+	fn register_with_fee_rejects_candidate_account_bound_to_alias() {
+		new_test_ext().execute_with(|| {
+			let lite_account = 107;
+			let alias_account = 108;
+			let alias_secret = register_lite_person(109, lite_account, 30);
+			let (_, alias) = establish_alias(&alias_secret, alias_account);
+			fund_lite_person_fee(alias_account);
+			let candidate_secret = secret_from_seed(31);
+
+			assert_noop!(
+				PeopleLitePallet::<Test>::register_with_fee(
+					Some(alias_account).into(),
+					member_from_secret(&candidate_secret),
+					sign_attest_with_secret(&candidate_secret, alias_account),
+					None,
+				),
+				crate::Error::<Test>::AccountInUse
+			);
+			assert_eq!(AccountToAlias::<Test>::get(alias_account), Some(alias));
+			assert!(!LitePeople::<Test>::contains_key(alias_account));
+			assert_eq!(pallet_balances::Pallet::<Test>::free_balance(alias_account), 100);
+			assert_eq!(
+				pallet_balances::Pallet::<Test>::free_balance(
+					PeopleLitePallet::<Test>::lite_people_pot_id(),
+				),
+				0,
+			);
+		});
+	}
+
+	#[test]
 	fn register_with_fee_rejects_ring_key_already_in_use() {
 		new_test_ext().execute_with(|| {
 			let original_candidate = 98;

--- a/pallets/people-lite/src/tests.rs
+++ b/pallets/people-lite/src/tests.rs
@@ -1315,7 +1315,7 @@ fn set_alias_account_rejects_canonical_lite_account_as_alias_account() {
 		let err = exec_as_lite_alias_with_proof_tx(call, proof, 0)
 			.expect_err("canonical lite account must not enter alias storage");
 
-		assert_eq!(err.unwrap_dispatch().error, crate::Error::<Test>::AccountInUse.into());
+		assert_eq!(err.unwrap_dispatch().error, crate::Error::<Test>::AlreadyRegistered.into());
 		assert!(AccountToAlias::<Test>::get(lite_account).is_none());
 		assert!(AliasToAccount::<Test>::iter().next().is_none());
 	});


### PR DESCRIPTION
Closes #5

`attest` only rejected accounts registered as lite people, so an account already bound to a lite alias could also become a canonical lite person.

The call now rejects alias-bound candidates with `AccountInUse` before registration. A regression test establishes a real alias binding and verifies that attestation leaves the binding and allowance unchanged.

## Changes

- Add the `AccountToAlias` gate to `PeopleLite::attest`.
- Add a regression test for an alias-bound candidate.