### PR TITLE
[nft-credits] rate limit for credit trees replay

### DIFF
--- a/pallets/nft-credits/src/lib.rs
+++ b/pallets/nft-credits/src/lib.rs
@@ -69,7 +69,8 @@
 //! Every recorded root is queued in [`CreditTreeDeliveryQueue`] under a contiguous sequence number,
 //! and the offchain worker ships a message's worth per block with [`Pallet::send_credit_trees`]. A
 //! tree that never arrives is repaired by [`Pallet::replay_credit_trees`], which anyone may call
-//! and which carries no sequence number.
+//! and which carries no sequence number. One replay allowed per [`Config::ReplayCooldownSeconds`],
+//! so as not to congest the channel.
 //!
 //! ## Claiming
 //!
@@ -251,14 +252,21 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxCreditTreesPerMessage: Get<u32>;
 
+		/// Cooldown, in seconds, between credit tree replays.
+		///
+		/// [`Pallet::replay_credit_trees`] is permissionless, so this is what bounds the XCMP
+		/// traffic it can cause.
+		#[pallet::constant]
+		type ReplayCooldownSeconds: Get<u64>;
+
 		/// Per-tree weight surcharge for executing `receive_credit_trees` on
 		/// [`Config::NftClaimsParaId`], charged to the caller of
 		/// [`Pallet::replay_credit_trees`].
 		///
-		/// The fee it buys is what limits how much replay traffic anyone can cause, that call
-		/// being permissionless and deliberately not rate-limited, so set it to at least the
-		/// per-tree cost of `receive_credit_trees` in the claims chain's own generated weights,
-		/// proof size included. A value below that leaves the remote work underpaid.
+		/// This prices the remote work a replay causes; [`Config::ReplayCooldownSeconds`] is what
+		/// bounds how often one can happen. Set it to at least the per-tree cost of
+		/// `receive_credit_trees` in the claims chain's own generated weights, proof size
+		/// included.
 		#[pallet::constant]
 		type NftClaimsRemoteWeight: Get<Weight>;
 
@@ -414,6 +422,13 @@ pub mod pallet {
 		ValueQuery,
 	>;
 
+	/// The time of the last credit tree replay, in seconds.
+	///
+	/// [`Pallet::replay_credit_trees`] refuses to run again within
+	/// [`Config::ReplayCooldownSeconds`] of it.
+	#[pallet::storage]
+	pub type LastReplayTime<T: Config> = StorageValue<_, u64, OptionQuery>;
+
 	/// The sequence number the next queued credit tree is delivered under.
 	///
 	/// Only a tree that made it into [`CreditTreeDeliveryQueue`] consumes one, so the sequence the
@@ -475,6 +490,9 @@ pub mod pallet {
 		UnsortedReplayBlocks,
 		/// None of the blocks to replay has a credit tree.
 		NoCreditTreeForBlock,
+		/// A credit tree replay ran within `ReplayCooldownSeconds` of the last one. The window is
+		/// shared by every caller.
+		ReplayCooldownActive,
 		/// The replay does not fit what the HRMP channel to the NFT claims chain can carry in
 		/// one message.
 		ExceedsClaimsChannelCapacity,
@@ -564,11 +582,11 @@ pub mod pallet {
 		/// cannot disturb the claims chain's tracking of the live stream, and one the claims chain
 		/// already holds is ignored there rather than overwriting anything.
 		///
+		/// One replay runs per [`Config::ReplayCooldownSeconds`], counted from the last one by
+		/// [`LastReplayTime`].
+		///
 		/// The caller pays for the remote work, [`Config::NftClaimsRemoteWeight`] per tree on top
-		/// of this call's own weight, and that fee is the only thing limiting how often anyone may
-		/// repair. It is deliberately not rate-limited: a limit shared between award blocks would
-		/// let a replay of any retained root, including one already delivered, consume the repair
-		/// capacity of the trees that really are missing.
+		/// of this call's own weight.
 		///
 		/// ## Parameters
 		/// - `blocks`: The award blocks to resend, in strictly ascending order.
@@ -1353,8 +1371,7 @@ impl<T: Config> Pallet<T> {
 	/// Resends the credit trees of `blocks`, as [`Pallet::replay_credit_trees`] does once its
 	/// origin is checked.
 	///
-	/// Only the fee limits how often this may run, for the reason the call documents: any limit
-	/// shared between award blocks would let one replay suppress every other repair.
+	/// The cooldown holds how often this may run.
 	pub(crate) fn do_replay_credit_trees(
 		blocks: BoundedVec<BlockNumberFor<T>, T::MaxCreditTreesPerMessage>,
 	) -> DispatchResult {
@@ -1368,8 +1385,17 @@ impl<T: Config> Pallet<T> {
 		let updates = Self::resolve_credit_trees(blocks.iter().map(|block| (None, *block)));
 		ensure!(!updates.is_empty(), Error::<T>::NoCreditTreeForBlock);
 
+		let now = T::UnixTime::now().as_secs();
+		if let Some(last) = LastReplayTime::<T>::get() {
+			ensure!(
+				now.saturating_sub(last) >= T::ReplayCooldownSeconds::get(),
+				Error::<T>::ReplayCooldownActive
+			);
+		}
+
 		let count = updates.len() as u32;
 		Self::send_credit_tree_batch(updates)?;
+		LastReplayTime::<T>::put(now);
 
 		Self::deposit_event(Event::<T>::CreditTreesReplayed { count });
 
@@ -1530,6 +1556,11 @@ impl<T: Config> Pallet<T> {
 			"replay_credit_trees",
 			<T as Config>::WeightInfo::replay_credit_trees(max_trees)
 				.saturating_add(T::NftClaimsRemoteWeight::get().saturating_mul(max_trees.into())),
+		);
+
+		assert!(
+			!T::ReplayCooldownSeconds::get().is_zero(),
+			"`ReplayCooldownSeconds` must be at least one",
 		);
 
 		// A ring with no room retains no awards at all, leaving every claim to be rebuilt

--- a/pallets/nft-credits/src/mock.rs
+++ b/pallets/nft-credits/src/mock.rs
@@ -69,6 +69,7 @@ impl crate::Config for Test {
 	type ChannelInfo = MockChannelInfo;
 	type MaxQueuedCreditTrees = MaxQueuedCreditTrees;
 	type MaxCreditTreesPerMessage = MaxCreditTreesPerMessage;
+	type ReplayCooldownSeconds = ReplayCooldownSeconds;
 	type NftClaimsRemoteWeight = NftClaimsRemoteWeight;
 	type MaxRetainedAwardBlocks = MaxRetainedAwardBlocks;
 	type MaxCreditBlocksPerClaimant = MaxCreditBlocksPerClaimant;
@@ -108,6 +109,7 @@ parameter_types! {
 	/// Small, so that a test can fill the delivery queue in a few blocks.
 	pub storage MaxQueuedCreditTrees: u32 = 8;
 	pub storage MaxCreditTreesPerMessage: u32 = 4;
+	pub const ReplayCooldownSeconds: u64 = 60;
 	pub const NftClaimsRemoteWeight: Weight = Weight::from_parts(1_000, 0);
 }
 

--- a/pallets/nft-credits/src/tests.rs
+++ b/pallets/nft-credits/src/tests.rs
@@ -1729,12 +1729,53 @@ mod credit_tree_delivery {
 		});
 	}
 
-	// A replay of one tree must not stand in the way of repairing another, whoever asks and
-	// however often: the call is permissionless, so any limit they shared would let a replay of
-	// an already-delivered root suppress the repair of a tree that really is missing. What a
-	// repair costs is charged to its caller instead.
 	#[test]
-	fn replay_credit_trees_does_not_rate_limit_a_repair() {
+	fn rejected_replay_starts_no_cooldown() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+			set_time(1_000);
+			queue_credit_tree(10);
+
+			assert_noop!(
+				NftCredits::replay_credit_trees(
+					RuntimeOrigin::signed(ALICE),
+					replay_blocks(vec![])
+				),
+				Error::<Test>::NoBlocksToReplay
+			);
+			assert_eq!(LastReplayTime::<Test>::get(), None);
+		});
+	}
+
+	#[test]
+	fn replay_credit_trees_rejects_a_second_replay_in_the_window() {
+		new_test_ext().execute_with(|| {
+			// `frame_system` drops events deposited at block zero.
+			System::set_block_number(1);
+			set_time(1_000);
+			queue_credit_tree(10);
+			queue_credit_tree(12);
+
+			assert_ok!(NftCredits::replay_credit_trees(
+				RuntimeOrigin::signed(BOB),
+				replay_blocks(vec![10])
+			));
+
+			// Another account, another tree, one second later.
+			set_time(1_001);
+			assert_noop!(
+				NftCredits::replay_credit_trees(
+					RuntimeOrigin::signed(ALICE),
+					replay_blocks(vec![12])
+				),
+				Error::<Test>::ReplayCooldownActive
+			);
+			assert_eq!(sent_credit_tree_xcms().len(), 1);
+		});
+	}
+
+	#[test]
+	fn replay_credit_trees_serves_a_repair_once_the_window_has_passed() {
 		new_test_ext().execute_with(|| {
 			// `frame_system` drops events deposited at block zero.
 			System::set_block_number(1);
@@ -1742,16 +1783,12 @@ mod credit_tree_delivery {
 			queue_credit_tree(10);
 			let missing = queue_credit_tree(12);
 
-			// An already-delivered tree, replayed by somebody else, in the same second.
-			assert_ok!(NftCredits::replay_credit_trees(
-				RuntimeOrigin::signed(BOB),
-				replay_blocks(vec![10])
-			));
 			assert_ok!(NftCredits::replay_credit_trees(
 				RuntimeOrigin::signed(BOB),
 				replay_blocks(vec![10])
 			));
 
+			set_time(1_000 + ReplayCooldownSeconds::get());
 			assert_ok!(NftCredits::replay_credit_trees(
 				RuntimeOrigin::signed(ALICE),
 				replay_blocks(vec![12])
@@ -1759,6 +1796,51 @@ mod credit_tree_delivery {
 			let batch = last_sent_credit_tree_batch();
 			assert_eq!(batch.trees.len(), 1);
 			assert_eq!(batch.trees[0].tree, missing);
+		});
+	}
+
+	#[test]
+	fn the_replay_cooldown_does_not_hold_up_the_delivery_stream() {
+		new_test_ext().execute_with(|| {
+			// `frame_system` drops events deposited at block zero.
+			System::set_block_number(1);
+			set_time(1_000);
+			queue_credit_tree(10);
+			queue_credit_tree(12);
+
+			assert_ok!(NftCredits::replay_credit_trees(
+				RuntimeOrigin::signed(BOB),
+				replay_blocks(vec![10])
+			));
+
+			// Still inside the window.
+			assert_ok!(NftCredits::send_credit_trees(authorized_origin(), 0, 0));
+			assert!(CreditTreeDeliveryQueue::<Test>::get().is_empty());
+			assert_eq!(sent_credit_tree_xcms().len(), 2);
+		});
+	}
+
+	#[test]
+	fn an_invalid_replay_reports_itself_inside_the_window() {
+		new_test_ext().execute_with(|| {
+			// `frame_system` drops events deposited at block zero.
+			System::set_block_number(1);
+			set_time(1_000);
+			queue_credit_tree(10);
+			queue_credit_tree(12);
+
+			assert_ok!(NftCredits::replay_credit_trees(
+				RuntimeOrigin::signed(BOB),
+				replay_blocks(vec![10])
+			));
+
+			assert_noop!(
+				NftCredits::replay_credit_trees(
+					RuntimeOrigin::signed(BOB),
+					replay_blocks(vec![12, 10])
+				),
+				Error::<Test>::UnsortedReplayBlocks
+			);
 		});
 	}
 

--- a/runtimes/next-people-paseo/src/people.rs
+++ b/runtimes/next-people-paseo/src/people.rs
@@ -717,6 +717,7 @@ impl indiv_pallet_nft_credits::Config for Runtime {
 	// `replay_credit_trees`.
 	type MaxQueuedCreditTrees = ConstU32<256>;
 	type MaxCreditTreesPerMessage = ConstU32<32>;
+	type ReplayCooldownSeconds = ConstU64<60>;
 	type NftClaimsRemoteWeight = NftClaimsRemoteWeight;
 	// Entries are the distinct blocks a claimant was awarded in, not a window of consecutive
 	// ones, so the bound counts games rather than time. One game awards a claimant at most
@@ -1154,8 +1155,8 @@ impl
 parameter_types! {
 	/// Upper bound on what one credit tree of a `receive_credit_trees` batch costs to execute on
 	/// the NFT claims chain. Charged to the caller of `replay_credit_trees`, so a repair pays for
-	/// the remote work it causes, and the only thing bounding how much replay traffic anyone can
-	/// cause.
+	/// the remote work it causes. What bounds replay traffic is `ReplayCooldownSeconds`; this
+	/// prices the work the replays that pass it cause.
 	///
 	/// Derived from the marginal per-tree cost of `receive_credit_trees` on Asset Hub: one
 	/// `CreditTrees` read and write, the per-tree execution term, and the `max_size` of a


### PR DESCRIPTION
Ported from individuality repository where it's already approved: https://github.com/paritytech/individuality/pull/1339.

`replay_credit_trees` is permissionless and was limited only by the fee the caller pays for the remote work. That leaves the HRMP channel to the NFT claims chain open to congestion from repeated replays.

A cooldown now bounds how often a replay can run, shared by every caller.

## Changes

- Add `Config::ReplayCooldownSeconds` and the `LastReplayTime` storage value.
- `do_replay_credit_trees` fails with `Error::ReplayCooldownActive` when called within the cooldown of the last replay, and records the time on success.
- `integrity_test` asserts `ReplayCooldownSeconds` is not zero.
- Set the cooldown to 60 seconds in the People runtimes.