### PR TITLE
Cmd bot: assign BOT_DIR in shell, runner context is unavailable in job env

### DIFF
--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -127,7 +127,6 @@ jobs:
       CMD: ${{ github.event.inputs.cmd }}
       PR_BRANCH: ${{ github.event.inputs.pr_branch }}
       BASE_REPO: ${{ github.repository }}
-      BOT_DIR: ${{ runner.temp }}/cmd-bot
     outputs:
       weight_deviation: ${{ steps.weight_deviation.outputs.result }}
     steps:
@@ -213,6 +212,7 @@ jobs:
 
           # Run the bot scripts from the cmd-bot branch, not from the PR
           # checkout, so a PR cannot modify the code this job executes.
+          BOT_DIR="$RUNNER_TEMP/cmd-bot"
           rm -rf "$BOT_DIR"
           git clone --depth 1 --branch cmd-bot "https://github.com/$BASE_REPO" "$BOT_DIR"
 
@@ -240,7 +240,7 @@ jobs:
 
           report="$RUNNER_TEMP/weight-deviation.txt"
           status=0
-          python3 "$BOT_DIR/.github/scripts/weight_deviation.py" --base upstream/main --current HEAD > "$report" || status=$?
+          python3 "$RUNNER_TEMP/cmd-bot/.github/scripts/weight_deviation.py" --base upstream/main --current HEAD > "$report" || status=$?
 
           # Exit code 2 means high-variance changes were found. That is
           # informational for /cmd bench, so only fail on real errors.


### PR DESCRIPTION

`/cmd` fails at dispatch time: `gh workflow run cmd-run.yml --ref cmd-bot` is rejected with "Unrecognized named-value: 'runner'" because `BOT_DIR: ${{ runner.temp }}/cmd-bot` sits in job-level `env`, where the `runner` context is not available. Example failure: [run 32516790760](https://github.com/paritytech/individuality-community/actions/runs/32516790760/job/96880778004).

Note: the `cmd-bot` branch must be fast-forwarded to main after merge for the fix to take effect (`git push origin main:cmd-bot`).

## Changes

- Assign `BOT_DIR="$RUNNER_TEMP/cmd-bot"` in the shell of the cmd step instead of job-level `env`
- Use `$RUNNER_TEMP/cmd-bot` directly in the weight-deviation step