### PR TITLE
pallet-members: merge-rings is spammable. 

### DIFF
--- a/pallets/members/src/lib.rs
+++ b/pallets/members/src/lib.rs
@@ -381,7 +381,9 @@ pub mod pallet {
 		KeyNotFound,
 		/// Could not push member into the ring.
 		CouldNotPush,
-		/// Ring cannot be merged if it's the top ring.
+		/// The ring index is not valid for the requested operation: it is the top ring used for
+		/// onboarding, it refers to an empty ring, or the collection never created a ring at that
+		/// index.
 		InvalidRing,
 		/// Ring cannot be built while there are suspensions pending.
 		SuspensionsPending,
@@ -697,8 +699,8 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Merge the members in two rings into a single, new ring. In order for the rings to be
-		/// eligible for merging, they must be below 1/2 of max capacity, have no pending
-		/// suspensions and not be the top ring used for onboarding.
+		/// eligible for merging, they must both be non-empty existing rings, be below 1/2 of max
+		/// capacity, have no pending suspensions and not be the top ring used for onboarding.
 		///
 		/// Only [`RingMode::Flexible`] collections can be merged. Their ring size never exceeds
 		/// `MaxFlexibleRingExponent`, so all keys of a ring live on page 0.
@@ -722,25 +724,26 @@ pub mod pallet {
 				RingsState::<T>::get(identifier).append_only(),
 				Error::<T>::RemovalSessionInProgress
 			);
-			// Top ring that onboards new candidates cannot be merged. Identical rings cannot be
-			// merged.
+			// Identical rings cannot be merged.
+			ensure!(base_ring_index != target_ring_index, Error::<T>::InvalidRing);
+			// Top ring that onboards new candidates cannot be merged. Further index as well.
 			let current_ring_index = CurrentRingIndex::<T>::get(identifier);
 			ensure!(
-				base_ring_index != target_ring_index &&
-					base_ring_index != current_ring_index &&
-					target_ring_index != current_ring_index,
+				base_ring_index < current_ring_index && target_ring_index < current_ring_index,
 				Error::<T>::InvalidRing
 			);
 
 			// Enforce eligibility criteria.
 			let (mut base_keys, mut base_ring_status) =
 				Self::ring_paged_keys_and_info(&identifier, base_ring_index, 0);
+			ensure!(!base_keys.is_empty(), Error::<T>::InvalidRing);
 			ensure!(base_keys.len() < max_ring_size / 2, Error::<T>::RingAboveMergeThreshold);
 			ensure!(
 				PendingSuspensions::<T>::decode_len(identifier, base_ring_index).unwrap_or(0) == 0,
 				Error::<T>::SuspensionsPending
 			);
 			let target_keys = RingKeys::<T>::get((identifier, target_ring_index, 0u32));
+			ensure!(!target_keys.is_empty(), Error::<T>::InvalidRing);
 			ensure!(target_keys.len() < max_ring_size / 2, Error::<T>::RingAboveMergeThreshold);
 			ensure!(
 				PendingSuspensions::<T>::decode_len(identifier, target_ring_index).unwrap_or(0) ==

--- a/pallets/members/src/lib.rs
+++ b/pallets/members/src/lib.rs
@@ -382,8 +382,7 @@ pub mod pallet {
 		/// Could not push member into the ring.
 		CouldNotPush,
 		/// The ring index is not valid for the requested operation: it is the top ring used for
-		/// onboarding, it refers to an empty ring, or the collection never created a ring at that
-		/// index.
+		/// onboarding or it refers to an empty ring.
 		InvalidRing,
 		/// Ring cannot be built while there are suspensions pending.
 		SuspensionsPending,
@@ -724,12 +723,13 @@ pub mod pallet {
 				RingsState::<T>::get(identifier).append_only(),
 				Error::<T>::RemovalSessionInProgress
 			);
-			// Identical rings cannot be merged.
-			ensure!(base_ring_index != target_ring_index, Error::<T>::InvalidRing);
-			// Top ring that onboards new candidates cannot be merged. Further index as well.
+			// Top ring that onboards new candidates cannot be merged. Identical rings cannot be
+			// merged.
 			let current_ring_index = CurrentRingIndex::<T>::get(identifier);
 			ensure!(
-				base_ring_index < current_ring_index && target_ring_index < current_ring_index,
+				base_ring_index != target_ring_index &&
+					base_ring_index != current_ring_index &&
+					target_ring_index != current_ring_index,
 				Error::<T>::InvalidRing
 			);
 

--- a/pallets/members/src/tests.rs
+++ b/pallets/members/src/tests.rs
@@ -1053,6 +1053,287 @@ mod merge_rings_tests {
 	}
 }
 
+/// `merge_rings` is a free call available to any signed account, so it must never accept ring
+/// indices that do not refer to two existing, populated rings. Otherwise it can be spammed to
+/// write junk into arbitrary ring indices, or to shuffle a real ring around the index space at no
+/// cost.
+mod merge_rings_spam_tests {
+	use super::*;
+
+	/// Keep building `ring_index` until every one of its keys is included in its root.
+	fn finish_ring_build(identifier: Identifier, ring_index: RingIndex) {
+		while let Some(to_include) = MembersPallet::should_build_ring(&identifier, ring_index, 255)
+		{
+			assert_ok!(MembersPallet::build_ring(&identifier, ring_index, to_include));
+		}
+	}
+
+	/// Add members with `add` and drive them all the way into a built `ring_index`.
+	fn build_ring_with_members<R>(
+		identifier: Identifier,
+		ring_index: RingIndex,
+		add: impl FnOnce() -> R,
+	) -> R {
+		let added = add();
+		while MembersPallet::onboard_members(&identifier, false) == Ok(true) {}
+		finish_ring_build(identifier, ring_index);
+		added
+	}
+
+	/// Calls `merge_rings` with far-out index pairs on a collection that has no ring at all, and
+	/// checks every call is rejected without writing any ring state.
+	#[test]
+	fn merge_rings_rejects_unused_ring_indices() {
+		TestExt::new().execute_with(|| {
+			System::set_block_number(1);
+			let identifier = TEST_IDENTIFIER;
+			create_test_collection(identifier, 1);
+
+			// No ring exists yet: the collection has no member at all.
+			assert_eq!(CurrentRingIndex::<Test>::get(identifier), 0);
+
+			for base in 1_000_000u32..1_000_010 {
+				assert_noop!(
+					MembersPallet::merge_rings(
+						RuntimeOrigin::signed(1),
+						identifier,
+						base,
+						base + 1_000,
+					),
+					Error::<Test>::InvalidRing
+				);
+			}
+
+			// No stale-ring markers and no ring statuses were written.
+			assert_eq!(StaleRings::<Test>::iter_prefix(identifier).count(), 0);
+			assert_eq!(RingKeysStatus::<Test>::iter_prefix(identifier).count(), 0);
+		});
+	}
+
+	/// Builds a real ring 0, then tries to pair it with never-used indices in both roles, checking
+	/// its root, status and member positions all stay put.
+	#[test]
+	fn merge_rings_cannot_relocate_a_ring_to_an_unused_index() {
+		TestExt::new().execute_with(|| {
+			System::set_block_number(1);
+			let identifier = TEST_IDENTIFIER;
+			create_test_collection(identifier, 1);
+
+			// Ring 0 gets 10 members, then the top ring moves to 1.
+			let members =
+				build_ring_with_members(identifier, 0, || generate_members(identifier, 1, 10));
+			manually_advance_to_ring(&identifier, 1);
+			assert!(Root::<Test>::contains_key(identifier, 0));
+
+			// Ring 0 cannot be moved to an index the collection never created a ring at, in either
+			// direction.
+			for base in 1_000_000u32..1_000_010 {
+				assert_noop!(
+					MembersPallet::merge_rings(RuntimeOrigin::signed(1), identifier, base, 0),
+					Error::<Test>::InvalidRing
+				);
+				assert_noop!(
+					MembersPallet::merge_rings(RuntimeOrigin::signed(1), identifier, 0, base),
+					Error::<Test>::InvalidRing
+				);
+			}
+
+			// Ring 0 is untouched: its root still stands and its members did not move.
+			assert!(Root::<Test>::contains_key(identifier, 0));
+			assert!(!StaleRings::<Test>::contains_key(identifier, 0));
+			assert_eq!(RingKeysStatus::<Test>::get(identifier, 0).total, 10);
+			for (member, _) in &members {
+				assert!(matches!(
+					Members::<Test>::get(identifier, member),
+					Some(RingPosition::Included { ring_index: 0, .. })
+				));
+			}
+			assert_eq!(OldRoots::<Test>::iter().count(), 0);
+		});
+	}
+
+	/// Sets up two populated rings that are otherwise eligible to merge, and checks the top ring
+	/// used for onboarding is refused in either role.
+	#[test]
+	fn merge_rings_rejects_the_top_ring() {
+		TestExt::new().execute_with(|| {
+			System::set_block_number(1);
+			let identifier = TEST_IDENTIFIER;
+			create_test_collection(identifier, 1);
+
+			// Ring 0 gets 10 members, then ring 1 becomes the top ring and gets 10 members too.
+			// Both rings are populated and below the merge threshold, so the only thing standing in
+			// the way of a merge is that ring 1 is the top ring that onboards new candidates.
+			build_ring_with_members(identifier, 0, || generate_members(identifier, 1, 10));
+			manually_advance_to_ring(&identifier, 1);
+			build_ring_with_members(identifier, 1, || {
+				generate_members_with_offset(identifier, 1, 10, 0xAA)
+			});
+
+			assert_eq!(CurrentRingIndex::<Test>::get(identifier), 1);
+			assert_eq!(RingKeysStatus::<Test>::get(identifier, 0).total, 10);
+			assert_eq!(RingKeysStatus::<Test>::get(identifier, 1).total, 10);
+
+			assert_noop!(
+				MembersPallet::merge_rings(RuntimeOrigin::signed(1), identifier, 1, 0),
+				Error::<Test>::InvalidRing
+			);
+			assert_noop!(
+				MembersPallet::merge_rings(RuntimeOrigin::signed(1), identifier, 0, 1),
+				Error::<Test>::InvalidRing
+			);
+		});
+	}
+
+	/// Fills three rings of a mutable collection, removes 3/4 of each so they become mergeable,
+	/// merges ring 0 into ring 1 and then ring 1 into ring 2, and checks that neither merged-away
+	/// ring can take part in a merge again, in any combination.
+	///
+	/// A `Flexible` (mutable) collection can shrink its rings through removals, which is what makes
+	/// them eligible for merging in the first place. Once a ring has been merged away its keys live
+	/// on another ring, so it must not be possible to merge it a second time — otherwise this free
+	/// call could be replayed against every index the collection has ever used.
+	#[test]
+	fn merged_away_rings_cannot_be_merged_again() {
+		TestExt::new().execute_with(|| {
+			System::set_block_number(1);
+			let identifier = TEST_IDENTIFIER;
+			create_test_collection(identifier, 1);
+
+			let ring_size = RingExponent::R2e9.ring_capacity() as usize;
+			let merge_threshold = ring_size / 2;
+			assert_eq!((ring_size, merge_threshold), (255, 127));
+
+			// Fill three rings. Onboarding advances the top ring index as each ring fills up, so
+			// rings 0, 1 and 2 all end up populated and ring 3 becomes the top ring.
+			let ring_members: Vec<Vec<MemberOf<Test>>> = [0xA0u8, 0xB0, 0xC0]
+				.into_iter()
+				.map(|offset| {
+					generate_members_with_offset(identifier, 1, 255, offset)
+						.into_iter()
+						.map(|(member, _)| member)
+						.collect()
+				})
+				.collect();
+			while MembersPallet::onboard_members(&identifier, false) == Ok(true) {}
+			for ring_index in 0..3 {
+				finish_ring_build(identifier, ring_index);
+				assert_eq!(
+					RingKeysStatus::<Test>::get(identifier, ring_index).total,
+					ring_size as u32
+				);
+			}
+			assert_eq!(CurrentRingIndex::<Test>::get(identifier), 3);
+
+			// Remove 3/4 of each ring, rounded up: 192 of 255, leaving 63 keys per ring. Two rings
+			// can then be merged into a third and the result still stays under the threshold, so
+			// the chain of merges below is only ever blocked by the rings themselves being gone.
+			let removed_per_ring = ring_size * 3 / 4 + 1;
+			assert_eq!(removed_per_ring, 192);
+			let kept_per_ring = ring_size - removed_per_ring;
+			assert_eq!(kept_per_ring, 63);
+
+			assert_ok!(<MembersPallet as FlexibleMembers>::start_removal_session(&identifier));
+			for members in &ring_members {
+				let removals: Vec<_> = members.iter().take(removed_per_ring).copied().collect();
+				assert_ok!(<MembersPallet as FlexibleMembers>::remove_members(
+					&identifier,
+					&removals
+				));
+			}
+			assert_ok!(<MembersPallet as FlexibleMembers>::end_removal_session(&identifier));
+			for ring_index in 0..3 {
+				MembersPallet::remove_suspended_keys(&identifier, ring_index);
+				finish_ring_build(identifier, ring_index);
+				assert_eq!(
+					RingKeysStatus::<Test>::get(identifier, ring_index).total,
+					kept_per_ring as u32
+				);
+			}
+
+			// Merge ring 0 into ring 1, then ring 1 into ring 2. Every surviving key ends up on
+			// ring 2 and rings 0 and 1 are left behind as merged-away indices.
+			assert_ok!(MembersPallet::merge_rings(RuntimeOrigin::signed(1), identifier, 1, 0));
+			assert_eq!(RingKeysStatus::<Test>::get(identifier, 1).total, 2 * kept_per_ring as u32);
+			finish_ring_build(identifier, 1);
+			assert_ok!(MembersPallet::merge_rings(RuntimeOrigin::signed(1), identifier, 2, 1));
+			assert_eq!(RingKeysStatus::<Test>::get(identifier, 2).total, 3 * kept_per_ring as u32);
+
+			// Rings 0 and 1 are gone: no keys, no status, no root, and nothing queued to rebuild.
+			for merged_away in [0u32, 1] {
+				assert!(RingKeys::<Test>::get((&identifier, merged_away, 0u32)).is_empty());
+				assert!(!RingKeysStatus::<Test>::contains_key(identifier, merged_away));
+				assert!(!Root::<Test>::contains_key(identifier, merged_away));
+				assert!(!StaleRings::<Test>::contains_key(identifier, merged_away));
+			}
+			for members in &ring_members {
+				for member in members.iter().skip(removed_per_ring) {
+					assert!(matches!(
+						Members::<Test>::get(identifier, member),
+						Some(RingPosition::Included { ring_index: 2, .. })
+					));
+				}
+			}
+
+			// A merged-away ring cannot be merged again, in either role or in any combination:
+			// rings 0 and 1 hold no keys, so they are no longer rings at all.
+			for (base, target) in [(0u32, 1u32), (1, 0), (0, 2), (1, 2)] {
+				assert_noop!(
+					MembersPallet::merge_rings(RuntimeOrigin::signed(1), identifier, base, target),
+					Error::<Test>::InvalidRing
+				);
+			}
+			// Ring 2 collected all three rings' keys, which puts it above the merge threshold, so
+			// it cannot absorb another ring either.
+			assert!(3 * kept_per_ring >= merge_threshold);
+			for (base, target) in [(2u32, 0u32), (2, 1)] {
+				assert_noop!(
+					MembersPallet::merge_rings(RuntimeOrigin::signed(1), identifier, base, target),
+					Error::<Test>::RingAboveMergeThreshold
+				);
+			}
+			// Ring 3 is the top ring and the collection never created a ring 4; neither of them is
+			// a merge partner.
+			for (base, target) in [(3u32, 2u32), (2, 3), (0, 3), (3, 0), (4, 2), (2, 4)] {
+				assert_noop!(
+					MembersPallet::merge_rings(RuntimeOrigin::signed(1), identifier, base, target),
+					Error::<Test>::InvalidRing
+				);
+			}
+
+			// After all the rejected attempts, ring 2 still holds every surviving key.
+			assert_eq!(RingKeysStatus::<Test>::get(identifier, 2).total, 3 * kept_per_ring as u32);
+			assert_eq!(RingKeys::<Test>::get((&identifier, 2u32, 0u32)).len(), 3 * kept_per_ring);
+			// Ring 2 is the only ring left with any state: rings 0 and 1 were cleaned up by the
+			// merges and the top ring 3 never had a member onboarded into it.
+			assert_eq!(RingKeysStatus::<Test>::iter_prefix(identifier).count(), 1);
+			// Ring 2 page 0 is the only place left holding keys.
+			let populated_pages: Vec<_> = RingKeys::<Test>::iter_prefix((identifier,))
+				.filter(|(_, keys)| !keys.is_empty())
+				.map(|((ring_index, page_index), keys)| (ring_index, page_index, keys.len()))
+				.collect();
+			assert_eq!(populated_pages, vec![(2, 0, 3 * kept_per_ring)]);
+
+			// FIXME: `onboard_members` leaves an empty page 1 behind on every ring it fills
+			// exactly, because the trailing `RingKeys::insert` writes the freshly incremented page
+			// index even when that page is empty. Flexible collections are single page, so these
+			// are storage dust that nothing ever reclaims: `merge_rings` and
+			// `remove_suspended_keys` only ever touch page 0. Pinned here so that fixing it breaks
+			// this assertion; the expectation then becomes `vec![(2, 0, 3 * kept_per_ring)]`,
+			// identical to `populated_pages` above.
+			let mut all_pages: Vec<_> = RingKeys::<Test>::iter_prefix((identifier,))
+				.map(|((ring_index, page_index), keys)| (ring_index, page_index, keys.len()))
+				.collect();
+			all_pages.sort();
+			assert_eq!(
+				all_pages,
+				vec![(0, 1, 0), (1, 1, 0), (2, 0, 3 * kept_per_ring), (2, 1, 0)],
+				"empty page 1 entries are leftover dust from onboarding, not live ring state"
+			);
+		});
+	}
+}
+
 mod set_onboarding_size_tests {
 	use super::*;
 

--- a/pallets/members/src/tests.rs
+++ b/pallets/members/src/tests.rs
@@ -1286,7 +1286,7 @@ mod merge_rings_spam_tests {
 			// Ring 2 collected all three rings' keys, which puts it above the merge threshold, so
 			// it cannot absorb another ring either.
 			assert!(3 * kept_per_ring >= merge_threshold);
-			for (base, target) in [(2u32, 0u32), (2, 1)] {
+			for (base, target) in [(2u32, 0u32), (2, 1), (2, 4)] {
 				assert_noop!(
 					MembersPallet::merge_rings(RuntimeOrigin::signed(1), identifier, base, target),
 					Error::<Test>::RingAboveMergeThreshold
@@ -1294,7 +1294,8 @@ mod merge_rings_spam_tests {
 			}
 			// Ring 3 is the top ring and the collection never created a ring 4; neither of them is
 			// a merge partner.
-			for (base, target) in [(3u32, 2u32), (2, 3), (0, 3), (3, 0), (4, 2), (2, 4)] {
+			for (base, target) in [(3u32, 2u32), (2, 3), (0, 3), (3, 0), (4, 2)] {
+				dbg!(base, target);
 				assert_noop!(
 					MembersPallet::merge_rings(RuntimeOrigin::signed(1), identifier, base, target),
 					Error::<Test>::InvalidRing

--- a/pallets/members/src/tests.rs
+++ b/pallets/members/src/tests.rs
@@ -1295,7 +1295,6 @@ mod merge_rings_spam_tests {
 			// Ring 3 is the top ring and the collection never created a ring 4; neither of them is
 			// a merge partner.
 			for (base, target) in [(3u32, 2u32), (2, 3), (0, 3), (3, 0), (4, 2)] {
-				dbg!(base, target);
 				assert_noop!(
 					MembersPallet::merge_rings(RuntimeOrigin::signed(1), identifier, base, target),
 					Error::<Test>::InvalidRing


### PR DESCRIPTION
# Issue

merge-rings can merge with empty rings and beyond the `current_ring_index` of the collection. One spam is to just merge half-removed ring into the index 100000001 then merge 100000001 into 100000002 etc... and merges are refunded on success so this is free. (And this even triggers the subscriber notifier process.)

# Fix

New additional condition to merge rings: both are non-empty.

Also there is another small unrelated issue with merged-away rings leaving empty pages but it is fixed in https://github.com/paritytech/individuality-community/pull/39