### PR TITLE
Disable crypto host calls in wasm

### DIFF
--- a/docs/examples/assethub-network.toml
+++ b/docs/examples/assethub-network.toml
@@ -29,14 +29,13 @@ chain = "rococo-local"
 default_command = "polkadot"
 default_args = ["--network-backend=libp2p", "--rpc-max-response-size=50"]
 
-# The People runtime calls the RFC-163 ECC host functions during PVF validation, and a
-# validator only registers them when its executor params ask for it. Without this the
-# People candidates are rejected with a missing `ext_host_calls_bls12_381_*` function
-# and the parachain stops being included a few blocks in. Applied as a genesis overlay
-# rather than a prebuilt relay spec so zombienet still generates the spec itself, which
-# is what puts the validator keys in the right keystores. Same setting as
-# `e2e/zombienet/network.toml`. A runtime built with the `ec-crypto-no-hostcalls`
-# feature does not need this setting.
+# The default runtimes compute the ring VRF elliptic curve operations in-runtime and do
+# not need this setting. Keep it so a runtime built with `ec-crypto-hostcalls` also runs
+# on this network: such a runtime calls the RFC-163 ECC host functions during PVF
+# validation, and a validator only registers them when its executor params ask for it.
+# Applied as a genesis overlay rather than a prebuilt relay spec so zombienet still
+# generates the spec itself, which is what puts the validator keys in the right
+# keystores. Same setting as `e2e/zombienet/network.toml`.
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
 executor_params = [{ EnabledHostFunction = "EccRfc163" }]
 

--- a/docs/examples/assethub-network.toml
+++ b/docs/examples/assethub-network.toml
@@ -35,7 +35,8 @@ default_args = ["--network-backend=libp2p", "--rpc-max-response-size=50"]
 # and the parachain stops being included a few blocks in. Applied as a genesis overlay
 # rather than a prebuilt relay spec so zombienet still generates the spec itself, which
 # is what puts the validator keys in the right keystores. Same setting as
-# `e2e/zombienet/network.toml`.
+# `e2e/zombienet/network.toml`. A runtime built with the `ec-crypto-no-hostcalls`
+# feature does not need this setting.
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
 executor_params = [{ EnabledHostFunction = "EccRfc163" }]
 

--- a/docs/examples/people-network.toml
+++ b/docs/examples/people-network.toml
@@ -13,7 +13,8 @@ default_args = ["--network-backend=libp2p", "--rpc-max-response-size=50"]
 # validator only registers them when its executor params ask for it. Without this the
 # People candidates are rejected with a missing `ext_host_calls_bls12_381_*` function
 # and the parachain stops being included a few blocks in. Same setting as
-# `e2e/zombienet/network.toml`.
+# `e2e/zombienet/network.toml`. A runtime built with the `ec-crypto-no-hostcalls`
+# feature does not need this setting.
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
 executor_params = [{ EnabledHostFunction = "EccRfc163" }]
 

--- a/docs/examples/people-network.toml
+++ b/docs/examples/people-network.toml
@@ -9,12 +9,11 @@ chain = "rococo-local"
 default_command = "polkadot"
 default_args = ["--network-backend=libp2p", "--rpc-max-response-size=50"]
 
-# The People runtime calls the RFC-163 ECC host functions during PVF validation, and a
-# validator only registers them when its executor params ask for it. Without this the
-# People candidates are rejected with a missing `ext_host_calls_bls12_381_*` function
-# and the parachain stops being included a few blocks in. Same setting as
-# `e2e/zombienet/network.toml`. A runtime built with the `ec-crypto-no-hostcalls`
-# feature does not need this setting.
+# The default People runtime computes the ring VRF elliptic curve operations in-runtime
+# and does not need this setting. Keep it so a runtime built with `ec-crypto-hostcalls`
+# also runs on this network: such a runtime calls the RFC-163 ECC host functions during
+# PVF validation, and a validator only registers them when its executor params ask for
+# it. Same setting as `e2e/zombienet/network.toml`.
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
 executor_params = [{ EnabledHostFunction = "EccRfc163" }]
 

--- a/e2e/zombienet/network.toml
+++ b/e2e/zombienet/network.toml
@@ -26,11 +26,11 @@ chain = "rococo-local"
 default_command = "polkadot"
 default_args = ["--network-backend=libp2p", "--rpc-max-response-size=50"]
 
-# The People runtime uses RFC-163 ECC host calls during PVF validation when the ZK
-# chunk payloads are decoded. Enable them in relay genesis so validators don't reject
-# those candidates with missing `ext_host_calls_*` functions. Applied as a genesis
-# overlay (not a prebuilt chain_spec_path) so zombienet still generates the relay spec
-# itself (prevent node-derived validator keys being injects into the keystores).
+# The default People runtime computes the ring VRF elliptic curve operations in-runtime
+# and does not need any extra host functions. Keep the RFC-163 executor param enabled so
+# a runtime built with `ec-crypto-hostcalls` also runs on this network. Applied as a
+# genesis overlay (not a prebuilt chain_spec_path) so zombienet still generates the relay
+# spec itself (prevent node-derived validator keys being injected into the keystores).
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
 executor_params = [{ EnabledHostFunction = "EccRfc163" }]
 

--- a/runtimes/next-asset-hub-paseo/Cargo.toml
+++ b/runtimes/next-asset-hub-paseo/Cargo.toml
@@ -500,6 +500,11 @@ std = [
 	"xcm/std",
 ]
 
+# Build the ring VRF suite with in-runtime arkworks code instead of the RFC-163 host
+# functions, for chains whose validators do not expose them. Weights in this repository
+# are measured against the host-accelerated backend and do not hold for this build.
+ec-crypto-no-hostcalls = ["indiv-support/ec-crypto-no-hostcalls"]
+
 # Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
 metadata-hash = ["substrate-wasm-builder?/metadata-hash"]
 

--- a/runtimes/next-asset-hub-paseo/Cargo.toml
+++ b/runtimes/next-asset-hub-paseo/Cargo.toml
@@ -500,10 +500,11 @@ std = [
 	"xcm/std",
 ]
 
-# Build the ring VRF suite with in-runtime arkworks code instead of the RFC-163 host
-# functions, for chains whose validators do not expose them. Weights in this repository
-# are measured against the host-accelerated backend and do not hold for this build.
-ec-crypto-no-hostcalls = ["indiv-support/ec-crypto-no-hostcalls"]
+# Build the ring VRF suite with the RFC-163 EC host functions instead of the default
+# in-runtime arkworks code. A runtime built with this only runs on validators that
+# expose those host functions (executor param `EccRfc163`). Weights in this repository
+# are measured against the default in-runtime backend.
+ec-crypto-hostcalls = ["indiv-support/ec-crypto-hostcalls"]
 
 # Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
 metadata-hash = ["substrate-wasm-builder?/metadata-hash"]

--- a/runtimes/next-people-paseo/Cargo.toml
+++ b/runtimes/next-people-paseo/Cargo.toml
@@ -290,10 +290,11 @@ coinage-benchmark-proof-cache-regenerate = [
 	"indiv-pallet-coinage/benchmark-proof-cache-regenerate",
 ]
 
-# Build the ring VRF suite with in-runtime arkworks code instead of the RFC-163 host
-# functions, for chains whose validators do not expose them. Weights in this repository
-# are measured against the host-accelerated backend and do not hold for this build.
-ec-crypto-no-hostcalls = ["indiv-support/ec-crypto-no-hostcalls"]
+# Build the ring VRF suite with the RFC-163 EC host functions instead of the default
+# in-runtime arkworks code. A runtime built with this only runs on validators that
+# expose those host functions (executor param `EccRfc163`). Weights in this repository
+# are measured against the default in-runtime backend.
+ec-crypto-hostcalls = ["indiv-support/ec-crypto-hostcalls"]
 
 try-runtime = [
 	"assets-common/try-runtime",

--- a/runtimes/next-people-paseo/Cargo.toml
+++ b/runtimes/next-people-paseo/Cargo.toml
@@ -290,6 +290,11 @@ coinage-benchmark-proof-cache-regenerate = [
 	"indiv-pallet-coinage/benchmark-proof-cache-regenerate",
 ]
 
+# Build the ring VRF suite with in-runtime arkworks code instead of the RFC-163 host
+# functions, for chains whose validators do not expose them. Weights in this repository
+# are measured against the host-accelerated backend and do not hold for this build.
+ec-crypto-no-hostcalls = ["indiv-support/ec-crypto-no-hostcalls"]
+
 try-runtime = [
 	"assets-common/try-runtime",
 	"cumulus-pallet-aura-ext/try-runtime",

--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -66,6 +66,7 @@ std = [
 	"verifiable/std",
 ]
 ec-crypto-hostcalls = []
+ec-crypto-no-hostcalls = []
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",

--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -66,7 +66,6 @@ std = [
 	"verifiable/std",
 ]
 ec-crypto-hostcalls = []
-ec-crypto-no-hostcalls = []
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",

--- a/support/src/crypto.rs
+++ b/support/src/crypto.rs
@@ -18,19 +18,35 @@
 //!
 //! Defines the concrete ring VRF suite and verifiable type used across the workspace.
 //!
-//! In `no_std` builds (on-chain), the suite uses host-accelerated elliptic curve operations
-//! provided by `sp-crypto-ec-utils`. In `std` builds the original arkworks types are used
-//! directly, unless the `ec-crypto-hostcalls` feature is explicitly enabled.
+//! The suite has two interchangeable backends with identical outputs. The host-accelerated
+//! backend offloads elliptic curve operations to the RFC-163 host functions of
+//! `sp-crypto-ec-utils` and requires validators that expose them. The in-runtime backend
+//! computes everything with the upstream arkworks suite and runs on any validator, at a
+//! large execution cost.
+//!
+//! Selection is by build target with a feature override in each direction. `no_std` builds
+//! use the host-accelerated backend unless `ec-crypto-no-hostcalls` is enabled. `std` builds
+//! use the in-runtime backend unless `ec-crypto-hostcalls` is enabled. When both features
+//! are enabled, as under `--all-features`, `ec-crypto-hostcalls` wins.
 
-#[cfg(any(not(feature = "std"), feature = "ec-crypto-hostcalls"))]
+#[cfg(any(
+	feature = "ec-crypto-hostcalls",
+	all(not(feature = "std"), not(feature = "ec-crypto-no-hostcalls"))
+))]
 mod host_hooks;
 
-#[cfg(all(feature = "std", not(feature = "ec-crypto-hostcalls")))]
+#[cfg(all(
+	not(feature = "ec-crypto-hostcalls"),
+	any(feature = "std", feature = "ec-crypto-no-hostcalls")
+))]
 mod bandersnatch {
 	pub use verifiable::ring::ark_vrf::suites::bandersnatch::BandersnatchSha512Ell2 as BandersnatchSuite;
 }
 
-#[cfg(any(not(feature = "std"), feature = "ec-crypto-hostcalls"))]
+#[cfg(any(
+	feature = "ec-crypto-hostcalls",
+	all(not(feature = "std"), not(feature = "ec-crypto-no-hostcalls"))
+))]
 mod bandersnatch {
 	use alloc::borrow::Cow;
 	use spin::Once;

--- a/support/src/crypto.rs
+++ b/support/src/crypto.rs
@@ -18,35 +18,22 @@
 //!
 //! Defines the concrete ring VRF suite and verifiable type used across the workspace.
 //!
-//! The suite has two interchangeable backends with identical outputs. The host-accelerated
-//! backend offloads elliptic curve operations to the RFC-163 host functions of
-//! `sp-crypto-ec-utils` and requires validators that expose them. The in-runtime backend
-//! computes everything with the upstream arkworks suite and runs on any validator, at a
-//! large execution cost.
-//!
-//! Selection is by build target with a feature override in each direction. `no_std` builds
-//! use the host-accelerated backend unless `ec-crypto-no-hostcalls` is enabled. `std` builds
-//! use the in-runtime backend unless `ec-crypto-hostcalls` is enabled. When both features
-//! are enabled, as under `--all-features`, `ec-crypto-hostcalls` wins.
+//! The suite has two interchangeable backends with identical outputs. By default the
+//! upstream arkworks suite computes everything in-runtime and runs on any validator.
+//! The `ec-crypto-hostcalls` feature switches both `std` and `no_std` builds to a
+//! backend that offloads elliptic curve operations to the RFC-163 host functions of
+//! `sp-crypto-ec-utils`; a runtime built with it only runs on validators that expose
+//! those host functions.
 
-#[cfg(any(
-	feature = "ec-crypto-hostcalls",
-	all(not(feature = "std"), not(feature = "ec-crypto-no-hostcalls"))
-))]
+#[cfg(feature = "ec-crypto-hostcalls")]
 mod host_hooks;
 
-#[cfg(all(
-	not(feature = "ec-crypto-hostcalls"),
-	any(feature = "std", feature = "ec-crypto-no-hostcalls")
-))]
+#[cfg(not(feature = "ec-crypto-hostcalls"))]
 mod bandersnatch {
 	pub use verifiable::ring::ark_vrf::suites::bandersnatch::BandersnatchSha512Ell2 as BandersnatchSuite;
 }
 
-#[cfg(any(
-	feature = "ec-crypto-hostcalls",
-	all(not(feature = "std"), not(feature = "ec-crypto-no-hostcalls"))
-))]
+#[cfg(feature = "ec-crypto-hostcalls")]
 mod bandersnatch {
 	use alloc::borrow::Cow;
 	use spin::Once;

--- a/support/src/crypto/host_hooks.rs
+++ b/support/src/crypto/host_hooks.rs
@@ -42,8 +42,8 @@
 //! A wire mismatch would surface as a decode panic in wasm at run time, not
 //! at compile time. The tests in this module (compiled with the
 //! `ec-crypto-hostcalls` feature) run the real host functions natively and
-//! compare every hook against pure arkworks 0.6; together with the e2e
-//! runtime tests they are the check that closes this risk.
+//! compare every hook against pure arkworks 0.6; they are the check that
+//! closes this risk.
 //!
 //! # Removal
 //!


### PR DESCRIPTION
We are back to default being arkworks in wasm execution of crypto stuff. `ec-crypto-hostcalls` explicitly enables them for both wasm and std if needed.