### PR TITLE
Stamp per-nightly spec_version in runtime builds

### DIFF
--- a/.github/workflows/build-runtimes.yml
+++ b/.github/workflows/build-runtimes.yml
@@ -1,9 +1,16 @@
 name: Build runtimes
 
 # Shared srtool build for the two paseo runtimes. Called by the manual Release
-# and the nightly pre-release workflows so both ship identical artifacts.
+# and the nightly pre-release workflows; the nightly passes nightly: true so its
+# builds get a timestamped spec_version.
 on:
   workflow_call:
+    inputs:
+      nightly:
+        description: Stamp spec_version with base * 100 + nightly sequence so each nightly upgrades
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-runtimes:
@@ -20,6 +27,38 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # A runtime upgrade only executes when spec_version strictly increases,
+      # and the committed value changes only on manual releases, so a nightly
+      # built from the raw source can never upgrade a chain already running a
+      # previous nightly. Stamp spec_version as base * 100 + N, where base is
+      # the committed value and N the count of earlier nightly tags: the
+      # stamped number starts with the committed digits (2_000_039 becomes
+      # 200_003_9NN) and strictly increases per nightly. spec_version is a
+      # u32, and base digits + N cap at 9 digits, which fits; N saturates at
+      # 99, so a base must not see 100 nightlies — every manual release bumps
+      # the base, which resets N. Manual releases must keep the committed
+      # value below the stamped band of any nightly already applied on-chain
+      # (bumping 2_000_039 to 2_000_040 stays under 200_003_900, so a chain
+      # that took a nightly rejects that release; bump past the band when
+      # that matters).
+      - name: Stamp nightly spec_version
+        if: inputs.nightly
+        run: |
+          set -euo pipefail
+          LIB="${{ matrix.path }}/src/lib.rs"
+          git fetch --tags --quiet
+          N=$(git tag -l 'nightly-*' | wc -l | tr -d ' ')
+          if [ "$N" -ge 100 ]; then
+            echo "::error::nightly sequence $N does not fit two digits; bump the committed spec_version"
+            exit 1
+          fi
+          BASE=$(grep -oP 'spec_version:\s*\K[0-9_]+' "$LIB" | tr -d '_')
+          printf -v STAMP '%d%02d' "$BASE" "$N"
+          # Group the 9 digits as nnn_nnn_nnn to match the Rust literal style.
+          GROUPED=$(sed -E 's/(.{3})(.{3})(.{3})/\1_\2_\3/' <<< "$STAMP")
+          sed -i -E "s/spec_version:[[:space:]]*[0-9_]+/spec_version: ${GROUPED}/" "$LIB"
+          grep "spec_version:" "$LIB"
 
       - name: Build ${{ matrix.name }} runtime
         id: srtool_build

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -4,9 +4,13 @@ name: Nightly Release
 # main, so downstream CI can test against the newest runtime features without
 # waiting for a versioned v* release. Pre-releases are marked prerelease and
 # never become the latest release. Each one carries a short diff of the PRs it
-# includes since the previous nightly. A scheduled run is skipped when main has
-# no new commits since the previous nightly; a workflow_dispatch run always
-# releases.
+# includes since the previous nightly, and each build stamps a unique
+# spec_version (committed base * 100 + count of nightly tags) so a chain accepts
+# it over any earlier nightly. The tag is nightly-YYYY-MM-DD, with a -HHMM
+# suffix when that tag already exists, so a manual rerun in the same day
+# releases alongside the earlier one instead of overwriting it. A scheduled run
+# is skipped when main has no new commits since the previous nightly; a
+# workflow_dispatch run always releases.
 on:
   schedule:
     - cron: "3 2 * * *" # nightly, 02:03 UTC
@@ -57,6 +61,10 @@ jobs:
     needs: [check-changes]
     if: github.event_name == 'workflow_dispatch' || needs.check-changes.outputs.new-commits == 'true'
     uses: ./.github/workflows/build-runtimes.yml
+    with:
+      # Stamp spec_version with the run timestamp so each nightly can upgrade
+      # a chain already running a previous nightly.
+      nightly: true
 
   publish-nightly:
     runs-on: parity-ubuntu
@@ -93,9 +101,13 @@ jobs:
           for JSON in $(<<<$CONTEXT sort -sr)
           do
           RUNTIME_NAME=$(basename ${JSON} _srtool_output.json)
+          # The build stamps spec_version as committed base * 100 + nightly
+          # sequence, so a chain accepts this nightly over any earlier one.
+          # Surface it: the committed value is not what this wasm carries.
           tee -a RELEASE_NOTES.md <<-EOF
 
           ## ${RUNTIME_NAME}
+          spec_version: **$(WASM 'core_version | .specVersion')** (stamped: committed base * 100 + nightly sequence)
           ~~~
           🏋️ Runtime Size:           $(numfmt --to iec-i --format "%.2f" $(WASM size)) ($(WASM size) bytes)
           🗜 Compressed:             $(WASM 'compression | if .compressed then "Yes: \(1 - .size_compressed / .size_decompressed | . * 10000 | round / 100)%" else "No" end')
@@ -151,7 +163,19 @@ jobs:
 
       - name: Compute nightly tag
         id: tag
-        run: echo "tag=nightly-$(date -u +%F)" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          git fetch --tags --quiet
+          TAG=nightly-$(date -u +%F)
+          # A rerun in the same UTC day would otherwise reuse the earlier
+          # release under the same tag, overwriting its assets, so suffix the
+          # tag with the run time. The stamp counts all nightly-* tags, and a
+          # suffixed tag matches the glob, so the rerun also gets the next
+          # spec_version sequence.
+          if git tag -l "$TAG" | grep -q .; then
+            TAG="$TAG-$(date -u +%H%M)"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create nightly pre-release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -95,6 +95,15 @@ jobs:
 
           tee RELEASE_NOTES.md <<-EOF
           # Runtime info
+
+          ⚠️ **Nightlies are not on the stable upgrade path.** Each build stamps a
+          spec_version in the base * 100 + sequence band (\`2_000_039\` →
+          \`200_003_9NN\`), and a chain accepts an upgrade only when the new
+          spec_version is strictly higher. A chain that installs a nightly
+          therefore rejects the next stable release (\`2_000_040\` < the nightly
+          band) until a stable ships above the band. Use nightlies on forks,
+          testnets and fresh chains only.
+
           *These runtimes were built with **$(SRTOOL rustc)** using **[$(SRTOOL gen)](https://github.com/paritytech/srtool)***
           EOF
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,7 @@ jobs:
           tee -a RELEASE_NOTES.md <<-EOF
 
           ## ${RUNTIME_NAME}
+          spec_version: **$(WASM 'core_version | .specVersion')**
           ~~~
           🏋️ Runtime Size:           $(numfmt --to iec-i --format "%.2f" $(WASM size)) ($(WASM size) bytes)
           🗜 Compressed:             $(WASM 'compression | if .compressed then "Yes: \(1 - .size_compressed / .size_decompressed | . * 10000 | round / 100)%" else "No" end')

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Tagged releases ship the runtime WASM as release assets, built reproducibly with
 
 > Releases are not guaranteed to be present on every clone of this repository.
 
+### Nightly pre-releases
+
+Daily `nightly-*` pre-releases build the runtimes from the latest `main` so downstream CI can test new features early. Each nightly stamps its own `spec_version` (committed base × 100 + nightly sequence, e.g. `2_000_039` → `200_003_904`) so a chain accepts it over any earlier nightly.
+
+**Nightlies are not on the stable upgrade path.** A chain applies a runtime upgrade only when the new `spec_version` is strictly higher, and the stamped band is far above the stable one. A chain that installs a nightly then rejects the next stable release (`2_000_040` < `200_003_904`) until a stable ships above the band. Install nightlies on forks, testnets, and fresh chains only, never on a network that must later upgrade to stable releases.
+
 ## 🛠️ Operating a chain
 
 Running a deployed People chain? See the [Operations guide](./docs/operations.md) for the privileged tasks an operator performs — scheduling games, running airdrops, enabling coinage, and managing attestations and invites.


### PR DESCRIPTION
## Changes

- `build-runtimes.yml`: new `nightly` input. When set, a step before the srtool build stamps `spec_version` as `committed base * 100 + count of nightly tags` (e.g. `2_000_039` → `200_003_904`), so every nightly strictly increases and a chain accepts it over any earlier nightly. The stamp lives in the build workspace only; nothing is committed back. The step hard-fails if the sequence reaches 100 (two spare digits), which a base never reaches because every manual release bumps it.
- `nightly-release.yml`: passes `nightly: true`; the tag gains a `-HHMM` suffix when the plain `nightly-YYYY-MM-DD` tag already exists, so a manual rerun in the same day creates its own release and bumps the sequence instead of overwriting the earlier release's assets with a same-version build.
- Release notes (both `nightly-release.yml` and `publish.yml`) print each runtime's `spec_version` prominently, read from the built wasm's own srtool output, so what is shown is guaranteed to be what shipped.

Example stamps for the coming days (asset-hub / people):

| Nightly | asset-hub | people |
|---|---|---|
| 2026-08-26 | 200_003_905 | 100_003_605 |
| 2026-08-27 | 200_003_906 | 100_003_606 |
| 2026-08-28 | 200_003_907 | 100_003_607 |

Caveat, documented in the step comment: a manual release that bumps the committed base by +1 lands below the nightly band (`2_000_040` < `200_003_905`), so a chain that applied a nightly rejects such a release. The release must bump past the stamped band, or a follow-up can extend stamping to `publish.yml`.