### PR TITLE
Track the number of unloaded aliases per recycler ring

### DIFF
--- a/pallets/coinage/src/benchmarking.rs
+++ b/pallets/coinage/src/benchmarking.rs
@@ -1552,6 +1552,9 @@ mod benches {
 				AliasState::Unloaded,
 			);
 		}
+		// Keep the counter in step with the entries written above; `clean_unchecked` compares the
+		// two.
+		RecyclersUnloadedCount::<T>::insert((INSTANCE_ID, value, ring_index), m);
 
 		// Advance time past expiration
 		let status = T::MemberService::ring_status(&identifier, 0).expect("ring exists");

--- a/pallets/coinage/src/extension.rs
+++ b/pallets/coinage/src/extension.rs
@@ -842,9 +842,12 @@ impl<T: Config + Send + Sync> TransactionExtension<<T as frame_system::Config>::
 				retry_counter,
 			} => {
 				if result.is_err() {
-					RecyclerAliasStates::<T>::insert(
-						(instance_id, fee_recycler_value, fee_recycler_index, first_alias),
-						AliasState::Locked(Self::failed_dispatch_lock_with_retries(retry_counter)),
+					RecyclerManager::<T>::mark_unloaded_alias_locked(
+						instance_id,
+						fee_recycler_value,
+						fee_recycler_index,
+						first_alias,
+						Self::failed_dispatch_lock_with_retries(retry_counter),
 					);
 				} else {
 					// The premark from `prepare` persists; emit the event only now that the

--- a/pallets/coinage/src/lib.rs
+++ b/pallets/coinage/src/lib.rs
@@ -714,6 +714,7 @@ pub mod pallet {
 	///   it is in.
 	/// * [RecyclerAliasStates] - per-alias lock/unloaded state, indexed by instance, denomination
 	///   and ring index.
+	/// * [RecyclersUnloadedCount] - the number of unloaded aliases of each ring.
 	/// * [RecyclersDusting] - marks rings with deferred recycler dust pending removal.
 	/// * [RecyclersArchives] - archival commitments for cleaned rings that still hold recoverable
 	///   coins.
@@ -739,6 +740,7 @@ pub mod pallet {
 	///   it is in.
 	/// * [RecyclerAliasStates] - per-alias lock/unloaded state, indexed by instance, denomination
 	///   and ring index.
+	/// * [RecyclersUnloadedCount] - the number of unloaded aliases of each ring.
 	/// * [RecyclersDusting] - marks rings with deferred recycler dust pending removal.
 	/// * [RecyclersArchives] - archival commitments for cleaned rings that still hold recoverable
 	///   coins.
@@ -771,6 +773,7 @@ pub mod pallet {
 	///   it is in.
 	/// * [RecyclerAliasStates] - per-alias lock/unloaded state, indexed by instance, denomination
 	///   and ring index.
+	/// * [RecyclersUnloadedCount] - the number of unloaded aliases of each ring.
 	/// * [RecyclersDusting] - marks rings with deferred recycler dust pending removal.
 	/// * [RecyclersArchives] - archival commitments for cleaned rings that still hold recoverable
 	///   coins.
@@ -796,6 +799,7 @@ pub mod pallet {
 	///   it is in.
 	/// * [RecyclerAliasStates] - per-alias lock/unloaded state, indexed by instance, denomination
 	///   and ring index.
+	/// * [RecyclersUnloadedCount] - the number of unloaded aliases of each ring.
 	/// * [RecyclersDusting] - marks rings with deferred recycler dust pending removal.
 	/// * [RecyclersArchives] - archival commitments for cleaned rings that still hold recoverable
 	///   coins.
@@ -813,6 +817,34 @@ pub mod pallet {
 		AliasState,
 		OptionQuery,
 	>;
+
+	/// Number of aliases unloaded from each recycler ring.
+	///
+	/// Equals the number of [RecyclerAliasStates] entries of the ring in state
+	/// [`AliasState::Unloaded`], so `RingStatus::total` minus this value is the number of coins the
+	/// ring still holds. Absent for a ring that already had alias states when the count was
+	/// introduced, because recovering its number needs a scan; such a ring is never counted.
+	///
+	/// **WARNING**: Do not use this storage directly, use [`RecyclerManager`] type instead.
+	///
+	/// This storage item is managed by [`RecyclerManager`] and is part of a consistent set:
+	/// * [RecyclerCollectionCreated] - whether the collection exists for an instance and
+	///   denomination.
+	/// * [RecyclersLastRemovedRingIndex] - the last removed ring index for each instance and
+	///   denomination.
+	/// * [RecyclersCoinToRecycler] - the mapping from member key to the instance and denomination
+	///   it is in.
+	/// * [RecyclerAliasStates] - per-alias lock/unloaded state, indexed by instance, denomination
+	///   and ring index.
+	/// * [RecyclersUnloadedCount] - the number of unloaded aliases of each ring.
+	/// * [RecyclersDusting] - marks rings with deferred recycler dust pending removal.
+	/// * [RecyclersArchives] - archival commitments for cleaned rings that still hold recoverable
+	///   coins.
+	///
+	/// Ring members, pending members, and ring state are managed by [`Config::MemberService`].
+	#[pallet::storage]
+	pub type RecyclersUnloadedCount<T> =
+		StorageMap<_, Twox64Concat, (InstanceId, Denomination, RingIndex), u32, OptionQuery>;
 
 	/// Marks recycler rings that have deferred recycler dust pending removal.
 	///
@@ -832,6 +864,7 @@ pub mod pallet {
 	///   it is in.
 	/// * [RecyclerAliasStates] - per-alias lock/unloaded state, indexed by instance, denomination
 	///   and ring index.
+	/// * [RecyclersUnloadedCount] - the number of unloaded aliases of each ring.
 	/// * [RecyclersDusting] - marks rings with deferred recycler dust pending removal.
 	/// * [RecyclersArchives] - archival commitments for cleaned rings that still hold recoverable
 	///   coins.
@@ -866,6 +899,7 @@ pub mod pallet {
 	///   it is in.
 	/// * [RecyclerAliasStates] - per-alias lock/unloaded state, indexed by instance, denomination
 	///   and ring index.
+	/// * [RecyclersUnloadedCount] - the number of unloaded aliases of each ring.
 	/// * [RecyclersDusting] - marks rings with deferred recycler dust pending removal.
 	/// * [RecyclersArchives] - archival commitments for cleaned rings that still hold recoverable
 	///   coins.

--- a/pallets/coinage/src/recycler_manager.rs
+++ b/pallets/coinage/src/recycler_manager.rs
@@ -25,7 +25,7 @@ use alloc::{
 	vec::Vec,
 };
 use codec::Encode;
-use frame_support::traits::UnixTime;
+use frame_support::{defensive, traits::UnixTime};
 use indiv_support::{
 	traits::{AppendOnlyMembers, MembershipProver, RingMembershipProof, RingMode},
 	tx_priority,
@@ -355,14 +355,14 @@ impl<T: Config> RecyclerManager<T> {
 		Ok(alias)
 	}
 
-	/// Marks a single alias as unloaded.
+	/// Marks a single alias as unloaded and counts it in [`RecyclersUnloadedCount`].
 	/// Should only be called after successful validation via `validate_alias_proof`.
 	///
 	/// Overwrites any existing temporary lock for the alias because a successful unload consumes
-	/// it permanently.
+	/// it permanently. Use [`Self::mark_unloaded_alias_locked`] to undo the mark.
 	///
-	/// Does not emit [`Event::RecyclerAliasUnloaded`]: the caller must emit it if (and only if)
-	/// the mark persists. In particular the transaction-extension premark is reverted in
+	/// Does not emit [`Event::RecyclerAliasUnloaded`]: the caller must emit it if (and only if) the
+	/// mark persists. In particular the transaction-extension premark is reverted in
 	/// `post_dispatch` on dispatch failure, so it only emits the event on success.
 	pub fn mark_alias_unloaded(
 		instance_id: InstanceId,
@@ -370,10 +370,70 @@ impl<T: Config> RecyclerManager<T> {
 		index: RingIndex,
 		alias: Alias,
 	) {
-		RecyclerAliasStates::<T>::insert((instance_id, value, index, alias), AliasState::Unloaded);
+		// Read before the write below, which would make the ring look used. Every alias state of a
+		// ring is written through this function, so a ring that has state but no count is one that
+		// predates the count: it stays uncounted, since only a scan could recover its number.
+		let count = Self::unloaded_count(instance_id, value, index);
+
+		let previous =
+			RecyclerAliasStates::<T>::mutate((instance_id, value, index, alias), |state| {
+				state.replace(AliasState::Unloaded)
+			});
+
+		if let Some(count) = count.filter(|_| previous != Some(AliasState::Unloaded)) {
+			RecyclersUnloadedCount::<T>::insert(
+				(instance_id, value, index),
+				count.saturating_add(1),
+			);
+		}
 	}
 
-	fn has_pending_dust(instance_id: InstanceId, value: Denomination, index: RingIndex) -> bool {
+	/// Turns the unloaded mark of an alias into a temporary lock, and takes it out of
+	/// [`RecyclersUnloadedCount`] again.
+	///
+	/// This undoes [`Self::mark_alias_unloaded`] for a premark whose dispatch failed, leaving the
+	/// alias unloadable again once `lock` expires. The alias must still carry the premark: any
+	/// other state means the caller marked and locked out of step.
+	pub fn mark_unloaded_alias_locked(
+		instance_id: InstanceId,
+		value: Denomination,
+		index: RingIndex,
+		alias: Alias,
+		lock: LockInfo,
+	) {
+		let previous =
+			RecyclerAliasStates::<T>::mutate((instance_id, value, index, alias), |state| {
+				state.replace(AliasState::Locked(lock))
+			});
+
+		if previous != Some(AliasState::Unloaded) {
+			defensive!("coinage: locked an alias that was not marked unloaded", previous);
+			return;
+		}
+
+		RecyclersUnloadedCount::<T>::mutate((instance_id, value, index), |unloaded| {
+			if let Some(count) = unloaded {
+				*count = count.saturating_sub(1);
+			}
+		});
+	}
+
+	/// The number of aliases unloaded from a recycler ring, or `None` if the ring is not counted.
+	///
+	/// A ring that already had alias states when [`RecyclersUnloadedCount`] was introduced is never
+	/// counted, so a caller that needs its number has to scan [`RecyclerAliasStates`] over the
+	/// ring's prefix. A ring with no alias state at all has had no unload, so it reports zero
+	/// without ever having been written to.
+	pub fn unloaded_count(
+		instance_id: InstanceId,
+		value: Denomination,
+		index: RingIndex,
+	) -> Option<u32> {
+		RecyclersUnloadedCount::<T>::get((instance_id, value, index))
+			.or_else(|| (!Self::has_alias_states(instance_id, value, index)).then_some(0))
+	}
+
+	fn has_alias_states(instance_id: InstanceId, value: Denomination, index: RingIndex) -> bool {
 		RecyclerAliasStates::<T>::iter_prefix((instance_id, value, index))
 			.next()
 			.is_some()
@@ -565,6 +625,17 @@ impl<T: Config> RecyclerManager<T> {
 		let unloaded_count = unloaded_aliases.len() as u32;
 		let remaining = status.total.saturating_sub(unloaded_count);
 
+		// The ring goes away here, so drop its unloaded count. The scan above is the ground truth
+		// for `remaining`; the count only serves readers, and a mismatch on a counted ring means
+		// the two went out of step somewhere in the unload paths.
+		let counted = RecyclersUnloadedCount::<T>::take((instance_id, value, next_ring));
+		if counted.is_some_and(|counted| counted != unloaded_count) {
+			defensive!(
+				"coinage: unloaded count does not match the ring's unloaded aliases",
+				(counted, unloaded_count)
+			);
+		}
+
 		// Archive the recycler before removing the ring if it still has not-yet-unloaded coins, so
 		// a member can later recover their value via `unload_archived`. Commit to the
 		// unloaded-alias set together with the ring-VRF root, both still readable until
@@ -586,7 +657,7 @@ impl<T: Config> RecyclerManager<T> {
 		}
 
 		// Queue any deferred ring dust for bounded cleanup.
-		if Self::has_pending_dust(instance_id, value, next_ring) {
+		if Self::has_alias_states(instance_id, value, next_ring) {
 			pallet::RecyclersDusting::<T>::insert((instance_id, value, next_ring), ());
 		}
 

--- a/pallets/coinage/src/tests/mod.rs
+++ b/pallets/coinage/src/tests/mod.rs
@@ -43,6 +43,7 @@ mod test_pay_for_recycler_unload_fee_token_with_coin;
 mod test_pay_for_recycler_unload_fee_token_with_external_asset;
 mod test_pay_for_recycler_unload_fee_token_with_native;
 mod test_recycler_lifecycle;
+mod test_recycler_unloaded_count;
 mod test_split;
 mod test_sponsored_instance;
 mod test_transfer;

--- a/pallets/coinage/src/tests/test_recycler_unloaded_count.rs
+++ b/pallets/coinage/src/tests/test_recycler_unloaded_count.rs
@@ -1,0 +1,373 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Individuality.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for [`RecyclersUnloadedCount`], the per-ring count of unloaded aliases.
+//!
+//! The count exists so a reader can get the number of unloaded coins of a live recycler with one
+//! storage read instead of a scan over [`RecyclerAliasStates`]. Every test therefore also asserts
+//! the count against that scan.
+
+use crate::{mock::*, *};
+use indiv_support::traits::AppendOnlyMembers;
+use sp_runtime::bounded_vec;
+use verifiable::GenerateVerifiable;
+
+/// The number of unloaded aliases of a ring, counted by scanning [`RecyclerAliasStates`].
+///
+/// This is what [`RecyclersUnloadedCount`] replaces, so the tests compare the two.
+fn scan_unloaded(value: Denomination, index: RingIndex) -> u32 {
+	RecyclerAliasStates::<Test>::iter_prefix((TEST_INSTANCE_ID, value, index))
+		.filter(|(_, state)| matches!(state, AliasState::Unloaded))
+		.count() as u32
+}
+
+fn assert_unloaded_count(value: Denomination, index: RingIndex, expected: u32) {
+	assert_eq!(
+		RecyclerManager::<Test>::unloaded_count(TEST_INSTANCE_ID, value, index),
+		Some(expected),
+		"stored unloaded count"
+	);
+	assert_eq!(scan_unloaded(value, index), expected, "unloaded aliases in storage");
+}
+
+fn alias_of(secret: &Secret) -> Alias {
+	CryptoOf::<Test>::alias_in_context(secret, crate::pallet::UNLOADING_RECYCLER_CONTEXT.as_ref())
+		.unwrap()
+}
+
+/// The count follows final unloads only.
+///
+/// A failed dispatch leaves the fee alias premarked by `prepare` and then turned into a retry lock
+/// by `post_dispatch`, which must not count. The retry then unloads both aliases and adds two: one
+/// through the extension's `post_dispatch` (the fee alias) and one through
+/// [`RecyclerManager::unload`].
+#[test]
+fn unloaded_count_only_counts_final_unloads() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		setup_balances();
+
+		let value: Denomination = 0;
+		let dest = CHARLIE;
+		let (secrets, index, revision) = setup_recycler(value, 2, 0);
+		let alias0 = alias_of(&secrets[0]);
+		let alias1 = alias_of(&secrets[1]);
+
+		assert_unloaded_count(value, index, 0);
+
+		let call = crate::Call::<Test>::unload_recycler_into_external_asset {
+			instance_id: TEST_INSTANCE_ID,
+			aliases: bounded_vec![alias0, alias1],
+			value,
+			index,
+			revision,
+			to: dest,
+			max_fee: unload_token_fee_in_asset(),
+		};
+
+		// Validation quotes the conversion and accepts the call, then the swap takes more of the
+		// asset than the quote allowed, so the dispatch fails.
+		set_fee_conversion_swap_surcharge(1);
+		let ext =
+			build_unload_from_output_ext(call.clone(), value, index, revision, &secrets[0..2]);
+		let result = Executive::apply_extrinsic(ext);
+		assert!(matches!(result, Ok(Err(_))), "dispatch should fail: {result:?}");
+
+		// `alias0` carries a retry lock, `alias1` was reverted with the dispatch. Neither is a
+		// successful unload, so the count stays at zero.
+		assert!(
+			super::get_recycler_alias_lock_until(value, index, alias0).is_some(),
+			"failed dispatch should lock the fee alias for retry"
+		);
+		assert_unloaded_count(value, index, 0);
+
+		// Wait out the lock and retry against a market in line with its quote.
+		set_fee_conversion_swap_surcharge(0);
+		let lock_until = super::get_recycler_alias_lock_until(value, index, alias0)
+			.expect("failed dispatch should lock the alias");
+		advance_until_time(lock_until as u32);
+
+		let refreshed_ext =
+			build_unload_from_output_ext(call, value, index, revision, &secrets[0..2]);
+		let result = Executive::apply_extrinsic(refreshed_ext);
+		assert!(matches!(result, Ok(Ok(_))), "retry should succeed: {result:?}");
+
+		assert_unloaded_count(value, index, 2);
+	});
+}
+
+/// A second unload of a different alias adds one, and the count never double-counts an alias that
+/// was already unloaded: a repeat attempt is rejected before it can be marked again.
+#[test]
+fn unloaded_count_grows_once_per_alias() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		setup_balances();
+
+		let value: Denomination = 0;
+		let dest = CHARLIE;
+		let (secrets, index, revision) = setup_recycler(value, 3, 0);
+
+		let unload = |secret_range: core::ops::Range<usize>, to: u64| {
+			let aliases = secrets[secret_range.clone()].iter().map(alias_of).collect::<Vec<_>>();
+			let call = crate::Call::<Test>::unload_recycler_into_external_asset {
+				instance_id: TEST_INSTANCE_ID,
+				aliases: aliases.try_into().unwrap(),
+				value,
+				index,
+				revision,
+				to,
+				max_fee: unload_token_fee_in_asset(),
+			};
+			let ext =
+				build_unload_from_output_ext(call, value, index, revision, &secrets[secret_range]);
+			Executive::apply_extrinsic(ext)
+		};
+
+		assert_eq!(unload(0..2, dest), Ok(Ok(())));
+		assert_unloaded_count(value, index, 2);
+
+		assert_eq!(unload(2..3, dest + 1), Ok(Ok(())));
+		assert_unloaded_count(value, index, 3);
+
+		// The same alias again: rejected in validation, so the count is untouched.
+		assert_invalid(
+			build_unload_from_output_ext(
+				crate::Call::<Test>::unload_recycler_into_external_asset {
+					instance_id: TEST_INSTANCE_ID,
+					aliases: bounded_vec![alias_of(&secrets[2])],
+					value,
+					index,
+					revision,
+					to: dest + 2,
+					max_fee: unload_token_fee_in_asset(),
+				},
+				value,
+				index,
+				revision,
+				&secrets[2..3],
+			),
+			CustomInvalidity::RecyclerAlreadyUnloaded,
+		);
+		assert_unloaded_count(value, index, 3);
+	});
+}
+
+/// Cleaning an expired ring drops its count, which is what keeps the map bounded by the number of
+/// live rings. The alias states themselves are dusted separately and later.
+#[test]
+fn unloaded_count_is_dropped_when_the_ring_is_cleaned() {
+	new_test_ext().execute_with(|| {
+		setup_balances();
+
+		let value: Denomination = 0;
+		let ring_capacity = R2E10_RING_CAPACITY;
+		let dest = 5000u64;
+
+		// Fill ring 0 to capacity and start ring 1.
+		let (secrets, _index, _revision) = setup_recycler(value, ring_capacity + 1, 0);
+		for _ in 0..10 {
+			Members::process_maintenance();
+		}
+
+		let identifier = Coinage::recycler_collection_identifier(TEST_INSTANCE_ID, value);
+		let status = <Test as Config>::MemberService::ring_status(&identifier, 0).unwrap();
+		assert_eq!(status.total, ring_capacity);
+		let immutable_since =
+			status.immutable_since.expect("a full append-only ring is immutable") as u32;
+		let revision = <Test as Config>::MemberService::ring_revision(&identifier, 0).unwrap();
+
+		let aliases = secrets[0..5].iter().map(alias_of).collect::<Vec<_>>();
+		let call = crate::Call::<Test>::unload_recycler_into_external_asset {
+			instance_id: TEST_INSTANCE_ID,
+			aliases: aliases.try_into().unwrap(),
+			value,
+			index: 0,
+			revision,
+			to: dest,
+			max_fee: unload_token_fee_in_asset(),
+		};
+		let ext = build_unload_from_output_ext(call, value, 0, revision, &secrets[0..5]);
+		assert_eq!(Executive::apply_extrinsic(ext), Ok(Ok(())));
+
+		assert_unloaded_count(value, 0, 5);
+
+		// `RingStatus::total` minus the count is the number of coins the ring still holds, which is
+		// what the ring is archived with.
+		assert_eq!(
+			status.total -
+				RecyclerManager::<Test>::unloaded_count(TEST_INSTANCE_ID, value, 0)
+					.expect("the ring is counted"),
+			ring_capacity - 5
+		);
+
+		// Expire the ring and let the offchain worker clean it.
+		let expiration = get_u32::<<Test as crate::Config>::RecyclerExpirationTime>();
+		advance_until_time(immutable_since + expiration);
+		advance_block();
+
+		assert_eq!(RecyclersLastRemovedRingIndex::<Test>::get(TEST_INSTANCE_ID, value), Some(0));
+		assert!(
+			!RecyclersUnloadedCount::<Test>::contains_key((TEST_INSTANCE_ID, value, 0u32)),
+			"cleaning the ring must drop its unloaded count"
+		);
+		assert_eq!(
+			RecyclersArchives::<Test>::get((TEST_INSTANCE_ID, value, 0u32))
+				.unwrap()
+				.remaining,
+			ring_capacity - 5
+		);
+
+		// The alias states outlive the count until dusting clears them, which must not bring the
+		// count back.
+		assert_eq!(scan_unloaded(value, 0), 5);
+		assert_eq!(RecyclerManager::<Test>::unloaded_count(TEST_INSTANCE_ID, value, 0), None);
+	});
+}
+
+/// A ring that was already unloaded from when the count was introduced is never counted.
+///
+/// Its earlier unloads are only in [`RecyclerAliasStates`], so counting the later ones would give a
+/// partial number that reads like a complete one. Such a ring is recognised by having alias states
+/// but no count, and it keeps no count for the rest of its life.
+#[test]
+fn rings_that_predate_the_count_are_never_counted() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		setup_balances();
+
+		let value: Denomination = 0;
+		let dest = CHARLIE;
+		let (secrets, index, revision) = setup_recycler(value, 3, 0);
+
+		let unload = |secret: usize, to: u64| {
+			let call = crate::Call::<Test>::unload_recycler_into_external_asset {
+				instance_id: TEST_INSTANCE_ID,
+				aliases: bounded_vec![alias_of(&secrets[secret])],
+				value,
+				index,
+				revision,
+				to,
+				max_fee: unload_token_fee_in_asset(),
+			};
+			let ext = build_unload_from_output_ext(
+				call,
+				value,
+				index,
+				revision,
+				&secrets[secret..secret + 1],
+			);
+			Executive::apply_extrinsic(ext)
+		};
+
+		// Stand in for the state a runtime upgrade finds: a ring with an unload that was never
+		// counted, because the count did not exist when it happened.
+		assert_eq!(unload(0, dest), Ok(Ok(())));
+		RecyclersUnloadedCount::<Test>::remove((TEST_INSTANCE_ID, value, index));
+
+		// The ring has alias states but no count, so it stays uncounted rather than starting a
+		// partial one.
+		assert_eq!(unload(1, dest + 1), Ok(Ok(())));
+		assert_eq!(scan_unloaded(value, index), 2);
+		assert_eq!(RecyclerManager::<Test>::unloaded_count(TEST_INSTANCE_ID, value, index), None);
+
+		// Cleaning it must not report a mismatch between the missing count and the two aliases.
+		let cleaned = RecyclerAliasStates::<Test>::iter_prefix((TEST_INSTANCE_ID, value, index))
+			.filter(|(_, state)| matches!(state, AliasState::Unloaded))
+			.count();
+		assert_eq!(cleaned, 2);
+	});
+}
+
+/// A ring that has no alias state yet has had no unload, so its count can start at zero. This is
+/// what lets a ring created after the count was introduced be counted without a migration.
+#[test]
+fn a_ring_without_alias_states_starts_counting_from_zero() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		setup_balances();
+
+		let value: Denomination = 0;
+		let (secrets, index, revision) = setup_recycler(value, 2, 0);
+
+		// No alias state and no count entry: the ring is new, not one that predates the count, so
+		// it already reports zero without anything having been written for it.
+		assert_eq!(scan_unloaded(value, index), 0);
+		assert!(!RecyclersUnloadedCount::<Test>::contains_key((TEST_INSTANCE_ID, value, index)));
+		assert_unloaded_count(value, index, 0);
+
+		let call = crate::Call::<Test>::unload_recycler_into_external_asset {
+			instance_id: TEST_INSTANCE_ID,
+			aliases: bounded_vec![alias_of(&secrets[0])],
+			value,
+			index,
+			revision,
+			to: CHARLIE,
+			max_fee: unload_token_fee_in_asset(),
+		};
+		let ext = build_unload_from_output_ext(call, value, index, revision, &secrets[0..1]);
+		assert_eq!(Executive::apply_extrinsic(ext), Ok(Ok(())));
+
+		assert_unloaded_count(value, index, 1);
+	});
+}
+
+/// A failed dispatch is the one way a ring gets an alias state without an unload, and it must not
+/// leave the ring looking like one that predates the count.
+///
+/// The premark starts the count and the lock takes it back down to zero, so the entry stays and the
+/// next unload counts from there rather than treating the ring as uncounted.
+#[test]
+fn a_lock_left_by_a_failed_dispatch_keeps_the_ring_counted() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		setup_balances();
+
+		let value: Denomination = 0;
+		let (secrets, index, revision) = setup_recycler(value, 2, 0);
+		let alias0 = alias_of(&secrets[0]);
+
+		let call = crate::Call::<Test>::unload_recycler_into_external_asset {
+			instance_id: TEST_INSTANCE_ID,
+			aliases: bounded_vec![alias0],
+			value,
+			index,
+			revision,
+			to: CHARLIE,
+			max_fee: unload_token_fee_in_asset(),
+		};
+
+		set_fee_conversion_swap_surcharge(1);
+		let ext =
+			build_unload_from_output_ext(call.clone(), value, index, revision, &secrets[0..1]);
+		assert!(matches!(Executive::apply_extrinsic(ext), Ok(Err(_))));
+
+		// The ring now has an alias state, so the count entry has to be there already: otherwise
+		// the ring would be mistaken for one that predates the count.
+		assert!(super::get_recycler_alias_lock_until(value, index, alias0).is_some());
+		assert_unloaded_count(value, index, 0);
+
+		set_fee_conversion_swap_surcharge(0);
+		let lock_until = super::get_recycler_alias_lock_until(value, index, alias0)
+			.expect("failed dispatch should lock the alias");
+		advance_until_time(lock_until as u32);
+
+		let refreshed_ext =
+			build_unload_from_output_ext(call, value, index, revision, &secrets[0..1]);
+		assert!(matches!(Executive::apply_extrinsic(refreshed_ext), Ok(Ok(_))));
+		assert_unloaded_count(value, index, 1);
+	});
+}


### PR DESCRIPTION
Reading how many coins a live recycler has given out meant scanning every `RecyclerAliasStates` entry under the ring's prefix and decoding each value. There was no stored aggregate.

This stores the count per ring. No migration: every alias state is written through `mark_alias_unloaded`, so a ring with alias states but no count predates the count and stays uncounted, while a ring with no alias state has had no unload and counts from zero.

## Changes

- Add `RecyclersUnloadedCount: StorageMap<_, Twox64Concat, (InstanceId, Denomination, RingIndex), u32, OptionQuery>`. Absent means the ring is not counted.
- Add `RecyclerManager::unloaded_count(instance_id, value, index) -> Option<u32>`. `None` means the caller has to scan.
- `mark_alias_unloaded` increments the count; new `mark_unloaded_alias_locked(instance_id, value, index, alias, lock)` writes the failed-dispatch lock and decrements it. The transaction extension's `post_dispatch` calls the latter instead of writing `RecyclerAliasStates` itself.
- `clean_unchecked` drops the count with the ring, and logs a defensive error if a counted ring disagrees with its unloaded aliases.
- Rename `has_pending_dust` to `has_alias_states`.
- Tests: failed dispatch and retry, repeated unloads of one alias, cleanup, and the three counted/uncounted cases.
