### PR TITLE
CI: do not re-trigger some job on label

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["main", "release-*"]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 # cancel previous runs


### PR DESCRIPTION
Those jobs don't need to be re-triggered on label change:
- test-all (parity-large, 60 min)
- build-e2e-runtime-wasm
- e2e-ts-checks
- test-runtime-upgrade
- benchmark-runtime × 2 runtimes (matrix)
