### PR TITLE
Let lite people register and claim people-airdrops draws

### DIFF
--- a/runtimes/next-people-paseo/src/integration_tests/people_airdrops_flow.rs
+++ b/runtimes/next-people-paseo/src/integration_tests/people_airdrops_flow.rs
@@ -83,6 +83,40 @@ fn bind_alias_account(secret: &VrfSecret, context: Context, account: &sr25519::P
 	exec_as_alias_with_proof(secret, context, set_alias.into());
 }
 
+/// Bind `account` to the lite person's alias in `context`, the lite-tier counterpart of
+/// [`bind_alias_account`].
+fn bind_lite_alias_account(secret: &VrfSecret, context: Context, account: &sr25519::Pair) {
+	let set_alias = indiv_pallet_people_lite::Call::<Runtime>::set_alias_account {
+		account: pair_to_account_id(account),
+		valid_at_block: frame_system::Pallet::<Runtime>::block_number(),
+	};
+	let uxt = build_as_lite_alias_with_proof_ext(secret, context, set_alias.into());
+	Executive::apply_extrinsic(uxt)
+		.expect("the lite alias setup transaction is valid")
+		.expect("the lite alias setup dispatch succeeds");
+}
+
+/// Build a transaction dispatching `call` from the lite alias the account `who` is bound to,
+/// authenticated by `who`'s signature and nonce.
+fn build_as_lite_alias_with_account_ext(
+	who: &sr25519::Pair,
+	call: RuntimeCall,
+) -> UncheckedExtrinsic {
+	build_people_lite_auth_ext(
+		who,
+		indiv_pallet_people_lite::PeopleLiteAuthData::AsLiteAliasWithAccount,
+		call,
+	)
+}
+
+/// Dispatch `call` from the lite alias the account `who` is bound to, expecting success.
+fn exec_as_lite_alias_with_account(who: &sr25519::Pair, call: RuntimeCall) {
+	let uxt = build_as_lite_alias_with_account_ext(who, call);
+	Executive::apply_extrinsic(uxt)
+		.expect("the lite alias transaction is valid")
+		.expect("the lite alias dispatch succeeds");
+}
+
 /// Enable the external asset for airdrops and fund the people-airdrops prize source with
 /// `draws * MAX_WINNERS` prizes. `enable_asset` also debits the asset's minimum balance from
 /// the source to seed the pot's asset account.
@@ -168,6 +202,89 @@ fn person_registers_and_claims_a_draw() {
 
 		assert_eq!(FungibleExternalAsset::balance(&destination), AIRDROP_PRIZE_PER_WINNER);
 		assert!(!indiv_pallet_airdrop::Winners::<Runtime>::contains_key(event_id, &entry));
+	});
+}
+
+/// A lite person registers for a draw through their airdrop alias account and claims the prize,
+/// the same journey as a full person: draws are open to every proven person, whichever tier.
+#[test]
+fn lite_person_registers_and_claims_a_draw() {
+	new_test_ext().execute_with(|| {
+		let lite_pair = sr25519::Pair::from_seed(&[30u8; 32]);
+		let lite_secret = register_lite_person_for_integration(&lite_pair);
+		// The lite helper onboards and builds the ring synchronously, so no block has executed
+		// yet and the relay randomness that salts a scheduled draw is still empty.
+		advance_block();
+		let alias_account_pair = sr25519::Pair::from_seed(&[31u8; 32]);
+		bind_lite_alias_account(&lite_secret, people_airdrops_context(), &alias_account_pair);
+
+		setup_people_airdrops_prize_asset(1);
+		let event_id = schedule_one_draw();
+		drive_airdrop_to_registering(event_id);
+
+		let register = indiv_pallet_people_airdrops::Call::<Runtime>::register {
+			event_ids: vec![event_id].try_into().expect("one draw fits the batch"),
+		};
+		exec_as_lite_alias_with_account(&alias_account_pair, register.into());
+
+		let alias = Crypto::alias_in_context(&lite_secret, &people_airdrops_context()[..])
+			.expect("the lite person can derive their airdrop alias");
+		let entry = RegistrationEntry::Alias { alias };
+		let slot = indiv_pallet_people_airdrops::Pallet::<Runtime>::slot_for(
+			&event_id,
+			&indiv_pallet_people_airdrops::DrawSalts::<Runtime>::get(event_id)
+				.expect("a scheduled draw has a salt")
+				.0,
+			&alias,
+		);
+		assert_eq!(
+			indiv_pallet_airdrop::Registrations::<Runtime>::get(event_id, slot),
+			Some(entry.clone())
+		);
+
+		drive_airdrop_to_claiming(event_id);
+		assert!(indiv_pallet_airdrop::Winners::<Runtime>::contains_key(event_id, &entry));
+
+		// The prize goes to an account with no personhood and no alias binding.
+		let destination = Sr25519Keyring::Charlie.to_account_id();
+		assert_eq!(FungibleExternalAsset::balance(&destination), 0);
+		let claim = indiv_pallet_people_airdrops::Call::<Runtime>::claim {
+			event_id,
+			destination: destination.clone(),
+		};
+		exec_as_lite_alias_with_account(&alias_account_pair, claim.into());
+
+		assert_eq!(FungibleExternalAsset::balance(&destination), AIRDROP_PRIZE_PER_WINNER);
+		assert!(!indiv_pallet_airdrop::Winners::<Runtime>::contains_key(event_id, &entry));
+	});
+}
+
+/// A lite alias account bound in another context resolves to a lite person, but not to one in
+/// the people-airdrops context, so it cannot register.
+#[test]
+fn lite_alias_account_in_another_context_cannot_register() {
+	new_test_ext().execute_with(|| {
+		let lite_pair = sr25519::Pair::from_seed(&[40u8; 32]);
+		let lite_secret = register_lite_person_for_integration(&lite_pair);
+		// The lite helper onboards and builds the ring synchronously, so no block has executed
+		// yet and the relay randomness that salts a scheduled draw is still empty.
+		advance_block();
+		let alias_account_pair = sr25519::Pair::from_seed(&[41u8; 32]);
+		bind_lite_alias_account(&lite_secret, score_context(), &alias_account_pair);
+
+		setup_people_airdrops_prize_asset(1);
+		let event_id = schedule_one_draw();
+		drive_airdrop_to_registering(event_id);
+
+		let register = indiv_pallet_people_airdrops::Call::<Runtime>::register {
+			event_ids: vec![event_id].try_into().expect("one draw fits the batch"),
+		};
+		let uxt = build_as_lite_alias_with_account_ext(&alias_account_pair, register.into());
+
+		assert_eq!(
+			Executive::apply_extrinsic(uxt).expect("transaction is valid"),
+			Err(DispatchError::BadOrigin)
+		);
 	});
 }
 

--- a/runtimes/next-people-paseo/src/people.rs
+++ b/runtimes/next-people-paseo/src/people.rs
@@ -997,7 +997,14 @@ impl indiv_pallet_airdrop::benchmarking::BenchmarkHelper<Runtime> for AirdropBen
 impl indiv_pallet_people_airdrops::Config for Runtime {
 	type WeightInfo = weights::indiv_pallet_people_airdrops::WeightInfo<Runtime>;
 	type Suffix = NetworkSuffix;
-	type EnsurePerson = indiv_pallet_people::EnsurePersonalAliasInContext<Runtime>;
+	// Draws are open to every proven person, whichever tier: a full person's alias and a lite
+	// person's alias both resolve in the airdrops context. The two collections use distinct
+	// member keys, so their aliases are disjoint; a person holding both identities registers as
+	// two independent aliases, which is inherent to the two-tier design.
+	type EnsurePerson = frame_support::traits::EitherOf<
+		indiv_pallet_people::EnsurePersonalAliasInContext<Runtime>,
+		indiv_pallet_people_lite::EnsureLiteAliasInContext<Runtime>,
+	>;
 	type AirdropAssetId = <Runtime as pallet_assets::Config>::AssetId;
 	type AirdropAssetBalance = Balance;
 	type Airdrop = Airdrop;
@@ -1226,12 +1233,17 @@ parameter_types! {
 }
 
 // The contexts in which lite people may set up account aliases. The pallet's own authentication
-// context, and the score context, in which a lite person can designate an account to play the game.
+// context, the score context, in which a lite person can designate an account to play the game,
+// and the people-airdrops context, in which a lite person can designate an account to register
+// for and claim airdrop draws. Every context accepted by a pallet whose `EnsurePerson` admits
+// lite aliases needs an entry here, otherwise no account can be bound to a lite alias in that
+// context and the lite side of the person origin is unreachable.
 pub struct LitePeopleAccountContexts;
 impl frame_support::traits::Contains<Context> for LitePeopleAccountContexts {
 	fn contains(l: &Context) -> bool {
 		l == &indiv_pallet_people_lite::Pallet::<Runtime>::auth_context() ||
-			l == &indiv_pallet_score::Pallet::<Runtime>::score_context()
+			l == &indiv_pallet_score::Pallet::<Runtime>::score_context() ||
+			l == &indiv_pallet_people_airdrops::Pallet::<Runtime>::people_airdrops_context()
 	}
 }
 


### PR DESCRIPTION
Lets lite people participate in `PeopleAirdrops` draws: whitelists the people-airdrops context for lite account aliases and widens the pallet's person origin to accept lite aliases.

**Why:** The pallet is meant for every proven person, but on previewnet only full people can play. #48 registered the airdrops context in the *full-people* `AccountContexts` and its integration test exercised a full person, so the two lite-side gates were never hit: the lite pallet keeps its own context whitelist (`LitePeopleAccountContexts`, still auth + score only), and `EnsurePerson` was `EnsurePersonalAliasInContext`, which only matches the full-people `PersonalAlias` origin — even a bound lite alias dispatches to `BadOrigin`. Both gates confirmed live on previewnet with a garbage-proof probe: `set_alias_account` in the lite auth context fails `BadProof` (gate passed, proof checked), in the airdrops context it fails `Invalid::Call` (context gate).

**How:** Two runtime changes in `people.rs`: add `people_airdrops_context()` to `LitePeopleAccountContexts`, and set `EnsurePerson = EitherOf<EnsurePersonalAliasInContext, EnsureLiteAliasInContext>` — both yield `Success = Alias`, so the plain combinator suffices; full people are tried first. Aliases of the two tiers come from distinct member keys/collections, so they are disjoint registration entries; a person holding both identities registers as two aliases, inherent to the two-tier design. Other gates audited and already open: `AsLiteAliasWithAccount` re-checks only binding freshness (no context gate), `AsLiteAliasWithAccountRevised`'s context gate is covered by the same whitelist entry, and origin-restriction already grants `LiteAlias` a nonzero allowance.

Adds `lite_person_registers_and_claims_a_draw` and `lite_alias_account_in_another_context_cannot_register` mirroring the full-person tests; all 74 runtime integration tests pass, `runtime-benchmarks` check clean.