### PR TITLE
add storage version to all pallets

### DIFF
--- a/pallets/airdrop/src/lib.rs
+++ b/pallets/airdrop/src/lib.rs
@@ -144,7 +144,13 @@ pub mod pallet {
 	pub type SupportedAssets<T: Config> =
 		StorageMap<_, Twox64Concat, AssetIdOf<T>, AssetBalanceOf<T>>;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/alias-accounts/src/lib.rs
+++ b/pallets/alias-accounts/src/lib.rs
@@ -114,7 +114,13 @@ pub mod pallet {
 		<T as frame_system::Config>::AccountId,
 	>>::Balance;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/chunks-manager/src/lib.rs
+++ b/pallets/chunks-manager/src/lib.rs
@@ -90,7 +90,13 @@ pub mod pallet {
 		}
 	}
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/coinage/src/lib.rs
+++ b/pallets/coinage/src/lib.rs
@@ -658,7 +658,13 @@ pub mod pallet {
 		H256::from((unloaded_root, recycler_root).using_encoded(blake2_256))
 	}
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	/// All the coins in all instances currently circulating, keyed by owner.

--- a/pallets/dotns-gateway/src/lib.rs
+++ b/pallets/dotns-gateway/src/lib.rs
@@ -80,8 +80,9 @@ pub mod pallet {
 
 	const LOG_TARGET: &str = "runtime::indiv-pallet-dotns-gateway";
 
-	/// The in-code storage version. Bump it and add a migration when the layout of a
-	/// storage item changes; see [`migration`].
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version. See [`migration`] for the existing ones.
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
 	#[pallet::pallet]

--- a/pallets/dotns-gateway/src/migration.rs
+++ b/pallets/dotns-gateway/src/migration.rs
@@ -32,7 +32,9 @@ pub type MigrateV0ToV1<T> = VersionedMigration<
 	<T as frame_system::Config>::DbWeight,
 >;
 
-pub mod v1 {
+/// Version-unchecked migration logic. Private, so a runtime can only run it through the version
+/// gate [`MigrateV0ToV1`].
+mod v1 {
 	use super::*;
 	use crate::BaseLabel;
 

--- a/pallets/dummy-dim/src/lib.rs
+++ b/pallets/dummy-dim/src/lib.rs
@@ -43,7 +43,13 @@ pub mod pallet {
 	use frame_support::{pallet_prelude::*, Twox64Concat};
 	use frame_system::pallet_prelude::*;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	/// The configuration of the pallet dummy DIM.

--- a/pallets/game/src/lib.rs
+++ b/pallets/game/src/lib.rs
@@ -304,7 +304,13 @@ pub mod pallet {
 
 	pub(crate) const LOG_TARGET: &str = "runtime::indiv-pallet-game";
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/honour/src/lib.rs
+++ b/pallets/honour/src/lib.rs
@@ -64,7 +64,13 @@ pub mod pallet {
 	use sp_runtime::traits::{BadOrigin, Dispatchable};
 	use verifiable::GenerateVerifiable;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::origin]

--- a/pallets/members-notifier/src/lib.rs
+++ b/pallets/members-notifier/src/lib.rs
@@ -115,7 +115,13 @@ pub mod pallet {
 		SaturatedConversion, Saturating,
 	};
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/members-subscriber/src/lib.rs
+++ b/pallets/members-subscriber/src/lib.rs
@@ -81,7 +81,13 @@ pub mod pallet {
 	/// transaction pool.
 	const TX_LONGEVITY: u64 = 3;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/members/src/lib.rs
+++ b/pallets/members/src/lib.rs
@@ -90,7 +90,13 @@ pub mod pallet {
 	/// well under the block limit (500 entries ≈ 1.3 MiB PoV, leaving room for other transactions).
 	pub(crate) const ORPHANED_MEMBERS_REMOVAL_LIMIT: u32 = 500;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/mob-rule/src/lib.rs
+++ b/pallets/mob-rule/src/lib.rs
@@ -77,7 +77,13 @@ pub mod pallet {
 	pub(crate) type BalanceOf<T> =
 		<<T as Config>::Currency as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/network-suffix/src/lib.rs
+++ b/pallets/network-suffix/src/lib.rs
@@ -42,7 +42,13 @@ pub mod pallet {
 	use super::*;
 	use frame_system::pallet_prelude::*;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/nft-claims/src/lib.rs
+++ b/pallets/nft-claims/src/lib.rs
@@ -200,7 +200,13 @@ pub mod pallet {
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/nft-credits/src/lib.rs
+++ b/pallets/nft-credits/src/lib.rs
@@ -176,7 +176,13 @@ const LOG_TARGET: &str = "runtime::indiv-pallet-nft-credits";
 pub mod pallet {
 	use super::*;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	/// The credits are the game's own bookkeeping, so this pallet is configured on top of it and

--- a/pallets/origin-restriction/src/lib.rs
+++ b/pallets/origin-restriction/src/lib.rs
@@ -130,7 +130,13 @@ pub mod pallet {
 	pub(crate) type ProviderBlockNumberFor<T> =
 		<<T as Config>::BlockNumberProvider as BlockNumberProvider>::BlockNumber;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	/// The current usage for each entity.

--- a/pallets/people-airdrops/src/lib.rs
+++ b/pallets/people-airdrops/src/lib.rs
@@ -83,7 +83,13 @@ pub mod pallet {
 	pub type AirdropEventInfoOf<T> =
 		EventInfo<<T as Config>::AirdropAssetId, <T as Config>::AirdropAssetBalance>;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/people-lite/src/lib.rs
+++ b/pallets/people-lite/src/lib.rs
@@ -82,7 +82,13 @@ pub mod pallet {
 	/// Fixed-width namespaced storage identifier for the lite people collection.
 	pub use indiv_support::traits::PEOPLE_LITE_IDENTIFIER as LITE_PEOPLE_MEMBER_IDENTIFIER;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	/// Native balance used to pay the lite-person registration fee.

--- a/pallets/people-multi/src/lib.rs
+++ b/pallets/people-multi/src/lib.rs
@@ -103,7 +103,13 @@ pub mod pallet {
 		}
 	}
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/pgas/src/lib.rs
+++ b/pallets/pgas/src/lib.rs
@@ -108,7 +108,13 @@ pub mod pallet {
 
 	const LOG_TARGET: &str = "runtime::indiv-pallet-pgas";
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/proof-of-ink/src/lib.rs
+++ b/pallets/proof-of-ink/src/lib.rs
@@ -79,7 +79,13 @@ pub mod pallet {
 
 	const LOG_TARGET: &str = "runtime::indiv-pallet-proof-of-ink";
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	/// The configuration of the pallet proof-of-ink.

--- a/pallets/relay-randomness/src/lib.rs
+++ b/pallets/relay-randomness/src/lib.rs
@@ -139,7 +139,13 @@ pub mod pallet {
 	use cumulus_primitives_core::{relay_chain::well_known_keys, PersistedValidationData};
 	use frame_support::pallet_prelude::*;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/resources/src/lib.rs
+++ b/pallets/resources/src/lib.rs
@@ -86,7 +86,13 @@ pub mod pallet {
 	const LOG_TARGET: &str = "runtime::indiv-pallet-resources";
 	pub(crate) const SECONDS_PER_DAY: u64 = 86_400;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/scarcity/src/lib.rs
+++ b/pallets/scarcity/src/lib.rs
@@ -618,7 +618,9 @@ pub mod pallet {
 		StorageDeposit,
 	}
 
-	/// Version 1 added `transferability` to `ItemDefinition`.
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version. Version 1 added `transferability` to `ItemDefinition`; see [`crate::migration`].
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
 	#[pallet::pallet]

--- a/pallets/scarcity/src/migration.rs
+++ b/pallets/scarcity/src/migration.rs
@@ -39,7 +39,9 @@ pub type MigrateV0ToV1<T> = VersionedMigration<
 	<T as frame_system::Config>::DbWeight,
 >;
 
-pub mod v1 {
+/// Version-unchecked migration logic. Crate-private, so a runtime can only run it through the
+/// version gate [`MigrateV0ToV1`]. Tests reach it directly to show what the gate prevents.
+pub(crate) mod v1 {
 	use super::*;
 
 	/// An item definition as stored before item transferability existed.

--- a/pallets/score/src/lib.rs
+++ b/pallets/score/src/lib.rs
@@ -94,7 +94,13 @@ pub mod pallet {
 	/// far in the future.
 	const CUSTOM_ERROR_FAR_FUTURE: u8 = 87;
 
+	/// The in-code storage version. Bump it when the layout of a storage item changes and ship
+	/// the change as a [`frame_support::migrations::VersionedMigration`] from the old to the new
+	/// version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	/// Default personhood-threshold tiers, used as the storage default for


### PR DESCRIPTION
Sets storage version of all pallets to 0.

This will be a useful piece of checking for runtime migrations, and making sure at the runtime repos, via `try-runtime-cli`, that no migration is missing. 

Hence forth, all pallets, as discussed in #56 should declare via a label if they have a migration. If they do, the natural thing for them is to use `VersionedMigration` + bump the `storage_version`.


The storage version is written to the state (under a deterministic key, can be found in `frame-support` macros) by FRAME automatically. Then, `try-runtime-cli` can ensure that the version of storage version in state and written in the code are in-sync, post each runtime upgrade. 

<img width="1690" height="502" alt="Screenshot 2026-09-04 at 12 42 31" src="https://github.com/user-attachments/assets/55b19461-4c23-4914-aaf4-7bce87656b21" />
