### PR TITLE
Fix coinage benchmark `as_unload_token_from_output_tx_ext`

### DIFF
--- a/pallets/coinage/src/benchmarking.rs
+++ b/pallets/coinage/src/benchmarking.rs
@@ -3965,9 +3965,8 @@ mod benches {
 	fn as_unload_token_from_output_tx_ext() -> Result<(), BenchmarkError> {
 		common_setup::<T>();
 
-		let value = denomination_covering_unload_fee::<T>(
-			T::MinimumExponentForOutputUnloadFee::get()
-		);
+		let value =
+			denomination_covering_unload_fee::<T>(T::MinimumExponentForOutputUnloadFee::get());
 
 		let (index, revision, members) = setup_built_recycler::<T>(value, 1, 0);
 

--- a/pallets/coinage/src/benchmarking.rs
+++ b/pallets/coinage/src/benchmarking.rs
@@ -457,6 +457,25 @@ fn setup_multi_recyclers<T: Config>(
 	(inputs, sign_data, total_asset_amount)
 }
 
+/// Returns the first denomination from `start` that covers the unload fee and minimum balance.
+/// This keeps `FromOutput` benchmarks valid after deducting the fee. Call after `common_setup`.
+fn denomination_covering_unload_fee<T: Config>(start: Denomination) -> Denomination {
+	let fee = Pallet::<T>::quote_paid_unload_token_fee_in_asset(INSTANCE_ID)
+		.expect("fee should be available after setup");
+	let required = fee.saturating_add(T::Fungibles::minimum_balance(asset_id::<T>()));
+	let mut value = start;
+	while Pallet::<T>::denomination_to_asset_amount(asset_unit::<T>(), value).unwrap_or_default() <
+		required
+	{
+		assert!(
+			value < T::MaximumExponent::get(),
+			"no denomination up to the maximum exponent covers the unload fee and minimum balance"
+		);
+		value = value.saturating_add(1);
+	}
+	value
+}
+
 #[benchmarks(
 	where
 		<T as frame_system::Config>::RuntimeCall: From<Call<T>> +
@@ -486,22 +505,11 @@ mod benches {
 		// both the fee and the destination's minimum balance, otherwise the `n = 1` sample would
 		// fail (the remainder transfer drops below the existential deposit) and get skipped,
 		// leaving too few points to fit a slope.
-		let mut value = T::MinimumExponent::get();
-		if mode == UnloadFeeBenchMode::FromOutput {
-			let fee = Pallet::<T>::quote_paid_unload_token_fee_in_asset(INSTANCE_ID)
-				.expect("fee should be available after setup");
-			let required = fee.saturating_add(T::Fungibles::minimum_balance(asset_id::<T>()));
-			while Pallet::<T>::denomination_to_asset_amount(asset_unit::<T>(), value)
-				.unwrap_or_default() <
-				required
-			{
-				assert!(
-					value < T::MaximumExponent::get(),
-					"no denomination up to the maximum exponent covers the unload fee and minimum balance"
-				);
-				value = value.saturating_add(1);
-			}
-		}
+		let value = match mode {
+			UnloadFeeBenchMode::FromOutput =>
+				denomination_covering_unload_fee::<T>(T::MinimumExponent::get()),
+			UnloadFeeBenchMode::Prepaid => T::MinimumExponent::get(),
+		};
 		let (index, revision, members) = setup_built_recycler::<T>(value, n, 0);
 		let asset_amount = Pallet::<T>::denomination_to_asset_amount(asset_unit::<T>(), value)
 			.expect("denomination should be in range");
@@ -3957,8 +3965,9 @@ mod benches {
 	fn as_unload_token_from_output_tx_ext() -> Result<(), BenchmarkError> {
 		common_setup::<T>();
 
-		// Setup recycler with a denomination large enough for the penalty fee.
-		let value = T::MinimumExponentForOutputUnloadFee::get();
+		let value = denomination_covering_unload_fee::<T>(
+			T::MinimumExponentForOutputUnloadFee::get()
+		);
 
 		let (index, revision, members) = setup_built_recycler::<T>(value, 1, 0);
 


### PR DESCRIPTION
benchmark `as_unload_token_from_output_tx_ext` wanted to unload a coin which's value could not cover the unload fees throwing `UnloadedValueBelowFee`